### PR TITLE
[codex] upgrade to 26.506.31421

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,10 +16,10 @@ flake-utils.lib.eachSystem systems (
   system:
   let
     pkgs = import nixpkgs { inherit system; };
-    appVersion = "26.506.20924";
+    appVersion = "26.506.31421";
     codexZip = pkgs.fetchurl {
       url = "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-${appVersion}.zip";
-      hash = "sha256-Lvl6ykiBY6x4OFXZ1yaYEulytQGGYAhqMleo/QMWpHU=";
+      hash = "sha256-E+upxNWpA6fugMrZmhSiDvCBQXuU/J0ERqIuEb3Va+k=";
     };
     codex = self.packages.${system}.codex;
   in

--- a/nix/codex/default.nix
+++ b/nix/codex/default.nix
@@ -15,24 +15,24 @@ flake-utils.lib.eachSystem systems (
   system:
   let
     pkgs = import nixpkgs { inherit system; };
-    version = "0.129.0-alpha.15";
+    version = "0.130.0-alpha.5";
     platform =
       {
         aarch64-darwin = {
           npm = "darwin-arm64";
-          hash = "sha256-ooXq+LOupw37NzPVCvLlLZH9WhhlGHjg9vnzjmjilgs=";
+          hash = "sha256-fB7PuADZasjSnakh/o+QCUsCIMauuZLY0b7DilFf5xU=";
         };
         x86_64-darwin = {
           npm = "darwin-x64";
-          hash = "sha256-A0HuNRLL7MsS0GFzVx632erk5ERPoZh+gQdsRbr01Tc=";
+          hash = "sha256-y1PAKwWeccKbhEBAwVRopoKZ4TTLX2TqJSymcvBDI5k=";
         };
         aarch64-linux = {
           npm = "linux-arm64";
-          hash = "sha256-ySlxQ9H16fI2iWFm2DaDTHRcwlsxYJXlxPjxkM7zqOs=";
+          hash = "sha256-PBge7say/j726O7esbK/+YnBKa1i3UCPV2MTG8lE6f4=";
         };
         x86_64-linux = {
           npm = "linux-x64";
-          hash = "sha256-ZF5xv3mC5wmZnW73CzucNa+4fAC85dvhlmq+/h1TLZ0=";
+          hash = "sha256-jzqwvew+ke4C+nKT1OrpBDClhppCZeheWpZRwLrubVg=";
         };
       }
       .${system};

--- a/patches/sentry-disable-shell.patch
+++ b/patches/sentry-disable-shell.patch
@@ -1,5 +1,5 @@
---- a/.vite/build/workspace-root-drop-handler-CSnqqPxa.js
-+++ b/.vite/build/workspace-root-drop-handler-CSnqqPxa.js
+--- a/.vite/build/workspace-root-drop-handler-CVOJlSpQ.js
++++ b/.vite/build/workspace-root-drop-handler-CVOJlSpQ.js
 @@ -38845,6 +38845,7 @@
      i = e.y(n.version);
    return (
@@ -10,10 +10,10 @@
        release: i,
 --- a/.vite/build/worker.js
 +++ b/.vite/build/worker.js
-@@ -65667,6 +65667,7 @@
-   let n = oW(e.appVersion),
+@@ -65673,6 +65673,7 @@
+   let n = iW(e.appVersion),
      r = e.buildFlavor !== `prod`;
-   (QA({
+   (XA({
 +    enabled: !1,
      dsn: aq,
      environment: e.buildFlavor,

--- a/patches/sentry-disable-webview.patch
+++ b/patches/sentry-disable-webview.patch
@@ -1,10 +1,10 @@
---- a/webview/assets/apps-ReuD7AbY.js
-+++ b/webview/assets/apps-ReuD7AbY.js
-@@ -30539,6 +30539,7 @@
-     n = l(e.appVersion),
+--- a/webview/assets/apps-Cel-9d-y.js
++++ b/webview/assets/apps-Cel-9d-y.js
+@@ -30399,6 +30399,7 @@
+     n = C(e.appVersion),
      r = e.buildFlavor !== `prod`;
-   (Qw({
+   (Hw({
 +    enabled: !1,
-     dsn: h,
-     environment: tT,
-     release: d(n.version),
+     dsn: S,
+     environment: Gw,
+     release: v(n.version),

--- a/patches/webview-artifacts-pane.patch
+++ b/patches/webview-artifacts-pane.patch
@@ -1,5 +1,5 @@
---- a/webview/assets/statsig-8HjEJSa2.js
-+++ b/webview/assets/statsig-8HjEJSa2.js
+--- a/webview/assets/statsig-C22dY4zM.js
++++ b/webview/assets/statsig-C22dY4zM.js
 @@ -4466,6 +4466,7 @@
          return this._contextHandle;
        }

--- a/patches/webview-electron-shim-close-sidebar.patch
+++ b/patches/webview-electron-shim-close-sidebar.patch
@@ -1,14 +1,14 @@
---- a/webview/assets/settings-back-route-BP1PAtIA.js
-+++ b/webview/assets/settings-back-route-BP1PAtIA.js
+--- a/webview/assets/settings-back-route-D0yQuB-H.js
++++ b/webview/assets/settings-back-route-D0yQuB-H.js
 @@ -1,10 +1,12 @@
 +import { s as g } from "./chunk-Bj-mKKzh.js";
- import { Kn as e, zn as t } from "./apps-ReuD7AbY.js";
+ import { Kn as e, zn as t } from "./apps-Cel-9d-y.js";
 -import { t as n } from "./jsx-runtime-CtnhcczV.js";
 +import { n as _, t as n } from "./jsx-runtime-CtnhcczV.js";
  import { t as r } from "./clsx-DUH431RJ.js";
  import { t as i } from "./compiler-runtime-DU4FoEWg.js";
- import { B as a, K as o, _ as s, y as c } from "./vscode-api-CEWdDs3u.js";
- import { t as l } from "./badge-BjR1bLlG.js";
+ import { B as a, K as o, _ as s, y as c } from "./vscode-api-Dc9pX2Bc.js";
+ import { t as l } from "./badge-BAJmBmgK.js";
 -var u = i();
 +var u = i(),
 +  v = g(_());

--- a/patches/webview-initial-route.patch
+++ b/patches/webview-initial-route.patch
@@ -18,16 +18,16 @@
          o === !1 ? u(e) : r.startTransition(() => u(e));
        },
        [o],
---- a/webview/assets/apps-ReuD7AbY.js
-+++ b/webview/assets/apps-ReuD7AbY.js
-@@ -2380,8 +2380,8 @@
+--- a/webview/assets/apps-Cel-9d-y.js
++++ b/webview/assets/apps-Cel-9d-y.js
+@@ -2242,8 +2242,8 @@
    if (e == null) throw Error(`AppShellLayoutMotionContext is missing`);
    return e;
  }
--var va = P(I, !0),
--  ya = P(I, () => new Qt(1)),
-+var va = P(I, window.__ELECTRON_SHIM__.initialSidebarState),
-+  ya = P(I, () => new Qt(window.__ELECTRON_SHIM__.initialSidebarState)),
-   ba = P(L, !1),
-   xa = P(L, () => new Qt(0)),
-   Sa = P(L, !1),
+-var ca = P(I, !0),
+-  la = P(I, () => new Zt(1)),
++var ca = P(I, window.__ELECTRON_SHIM__.initialSidebarState),
++  la = P(I, () => new Zt(window.__ELECTRON_SHIM__.initialSidebarState)),
+   ua = P(L, !1),
+   da = P(L, () => new Zt(0)),
+   fa = P(L, !1),

--- a/patches/webview-prompt-search-param.patch
+++ b/patches/webview-prompt-search-param.patch
@@ -1,121 +1,121 @@
---- a/webview/assets/app-main-5BBxW9R3.js
-+++ b/webview/assets/app-main-5BBxW9R3.js
+--- a/webview/assets/app-main-Bucm979x.js
++++ b/webview/assets/app-main-Bucm979x.js
 @@ -716,6 +716,7 @@
-   c as Kr,
-   d as qr,
-   f as Jr,
+   c as Vr,
+   d as Hr,
+   f as Ur,
 +  h as useSearchParams,
-   i as Yr,
-   l as Xr,
-   n as Zr,
-@@ -21413,7 +21414,7 @@
+   i as Wr,
+   l as Gr,
+   n as Kr,
+@@ -21421,7 +21422,7 @@
    );
  }
  function QT(e) {
 -  let t = (0, Z.c)(156),
 +  let t = (0, Z.c)(158),
      { announcementStorybookOverride: n } = e,
-     r = U(xl),
-     i = U(K),
-@@ -21425,6 +21426,8 @@
-     m = No(),
-     h = Jr(),
-     g = ni(),
+     r = U(ml),
+     a = U(K),
+@@ -21433,6 +21434,8 @@
+     h = Oo(),
+     g = Ur(),
+     _ = Zr(),
 +    [searchParams] = useSearchParams(),
 +    searchParamsPrompt = searchParams.get(`prompt`),
-     _ = g.state,
-     v = _?.prefillArtifactPreviewFiles,
-     y;
-@@ -21936,13 +21939,16 @@
+     v = _.state,
+     y = v?.prefillArtifactPreviewFiles,
+     b;
+@@ -21944,13 +21947,16 @@
    t[120] !== be ||
-   t[121] !== k.kind ||
-   t[122] !== Be ||
--  t[123] !== Ve
-+  t[123] !== Ve ||
+   t[121] !== j.kind ||
+   t[122] !== ze ||
+-  t[123] !== He
++  t[123] !== He ||
 +  t[156] !== searchParamsPrompt
-     ? ((Et = Be
-         ? (0, $.jsx)(ba, {
+     ? ((Tt = ze
+         ? (0, $.jsx)(ha, {
              className: `w-full`,
              aboveComposerContent: be,
-             browserConversationId: V,
+             browserConversationId: ee,
              canStartRealtimeConversation: !0,
 +            defaultText: searchParamsPrompt ?? void 0,
 +            initialPrompt: searchParamsPrompt ?? void 0,
-             onLocalConversationCreated: te,
+             onLocalConversationCreated: ne,
              externalFooterVariant: `home`,
-             showExternalFooter: Ve,
-@@ -21955,6 +21961,7 @@
-       (t[121] = k.kind),
-       (t[122] = Be),
-       (t[123] = Ve),
+             showExternalFooter: He,
+@@ -21963,6 +21969,7 @@
+       (t[121] = j.kind),
+       (t[122] = ze),
+       (t[123] = He),
 +      (t[156] = searchParamsPrompt),
-       (t[124] = Et))
-     : (Et = t[124]);
-   let Dt;
-@@ -22023,13 +22030,18 @@
-       (t[140] = Mt))
-     : (Mt = t[140]);
-   let Nt;
--  t[141] !== te || t[142] !== ze || t[143] !== k.kind
-+  t[141] !== te ||
-+  t[142] !== ze ||
-+  t[143] !== k.kind ||
+       (t[124] = Tt))
+     : (Tt = t[124]);
+   let Et;
+@@ -22031,13 +22038,18 @@
+       (t[140] = jt))
+     : (jt = t[140]);
+   let Mt;
+-  t[141] !== ne || t[142] !== Re || t[143] !== j.kind
++  t[141] !== ne ||
++  t[142] !== Re ||
++  t[143] !== j.kind ||
 +  t[157] !== searchParamsPrompt
-     ? ((Nt = ze
-         ? (0, $.jsx)(ql, {
-             children: (0, $.jsx)(ba, {
-               browserConversationId: V,
+     ? ((Mt = Re
+         ? (0, $.jsx)(Vl, {
+             children: (0, $.jsx)(ha, {
+               browserConversationId: ee,
                canStartRealtimeConversation: !0,
                composerLayoutMode: `auto-single-line`,
 +              defaultText: searchParamsPrompt ?? void 0,
 +              initialPrompt: searchParamsPrompt ?? void 0,
-               onLocalConversationCreated: te,
+               onLocalConversationCreated: ne,
                showWorkspaceDropdownInFooter: !1,
-               hideRunLocationDropdownOverride: k.kind !== `git`,
-@@ -22041,6 +22053,7 @@
-       (t[141] = te),
-       (t[142] = ze),
-       (t[143] = k.kind),
+               hideRunLocationDropdownOverride: j.kind !== `git`,
+@@ -22049,6 +22061,7 @@
+       (t[141] = ne),
+       (t[142] = Re),
+       (t[143] = j.kind),
 +      (t[157] = searchParamsPrompt),
-       (t[144] = Nt))
-     : (Nt = t[144]);
-   let Pt;
---- a/webview/assets/composer-DSSvCaO6.js
-+++ b/webview/assets/composer-DSSvCaO6.js
-@@ -62795,6 +62795,7 @@
-   showPlanKeywordSuggestion: v,
+       (t[144] = Mt))
+     : (Mt = t[144]);
+   let Nt;
+--- a/webview/assets/composer-DawxvKsB.js
++++ b/webview/assets/composer-DawxvKsB.js
+@@ -62874,6 +62874,7 @@
+   showPlanKeywordSuggestion: g,
    composerModeAvailability: y,
-   placeholderText: S,
+   placeholderText: b,
 +  initialPrompt,
    composerLayoutMode: C,
    hotkeyWindowHomeOverflowMenu: w,
    onSubmitLocal: T,
-@@ -63204,7 +63205,14 @@
-       (fn && Nr(fn),
-         un && ji(un),
-         Mi != null && Di(Mi),
--        ln && ln !== Dn.getText() && Dn.setPromptText(ln),
-+        ln && ln !== Dn.getText()
-+          ? Dn.setPromptText(ln)
-+          : !ln &&
+@@ -63285,7 +63286,14 @@
+       (mn && Rr(mn),
+         dn && Ni(dn),
+         Pi != null && ji(Pi),
+-        un && un !== kn.getText() && kn.setPromptText(un),
++        un && un !== kn.getText()
++          ? kn.setPromptText(un)
++          : !un &&
 +              initialPrompt != null &&
 +              initialPrompt !== `` &&
-+              Dn.getText() === ``
-+            ? Dn.setPromptText(initialPrompt)
++              kn.getText() === ``
++            ? kn.setPromptText(initialPrompt)
 +            : null,
-         dn != null &&
-           dn.length > 0 &&
-           mi((e) => {
-@@ -63221,7 +63229,7 @@
+         fn != null &&
+           fn.length > 0 &&
+           _i((e) => {
+@@ -63302,7 +63310,7 @@
      });
    (0, Z.useEffect)(() => {
-     Pi();
--  }, [ln, un, dn, Mi]);
-+  }, [ln, un, dn, Mi, initialPrompt]);
-   let [Fi, Ii] = ai(`composer_prefill`),
-     Li = (0, Z.useEffectEvent)(() => {
-       Fi?.text &&
-@@ -64908,6 +64916,8 @@
+     Ii();
+-  }, [un, dn, fn, Pi]);
++  }, [un, dn, fn, Pi, initialPrompt]);
+   let [Li, Ri] = ai(`composer_prefill`),
+     zi = (0, Z.useEffectEvent)(() => {
+       Li?.text &&
+@@ -65002,6 +65010,8 @@
    hideRunLocationDropdownOverride: b = !1,
    composerModeAvailability: x,
    placeholderText: S,
@@ -124,9 +124,9 @@
    composerLayoutMode: C = `multiline`,
    hotkeyWindowHomeOverflowMenu: w,
    lockedCollaborationMode: T,
-@@ -65160,8 +65170,8 @@
+@@ -65254,8 +65264,8 @@
        (0, Q.jsxs)(
-         OU,
+         NU,
          {
 -          defaultText: I,
 -          defaultTextKind: ql(I) ? `prompt` : `plain`,
@@ -135,7 +135,7 @@
            children: [
              !v && r && i === `floating`
                ? (0, Q.jsx)(`div`, {
-@@ -65196,6 +65206,7 @@
+@@ -65290,6 +65300,7 @@
                placeholderText: S,
                composerLayoutMode: C,
                hotkeyWindowHomeOverflowMenu: w,

--- a/patches/webview-prosemirror-inputmode.patch
+++ b/patches/webview-prosemirror-inputmode.patch
@@ -1,5 +1,5 @@
---- a/webview/assets/prompt-editor-BFzgDIHO.js
-+++ b/webview/assets/prompt-editor-BFzgDIHO.js
+--- a/webview/assets/prompt-editor-CKc_N6kw.js
++++ b/webview/assets/prompt-editor-CKc_N6kw.js
 @@ -24273,6 +24273,13 @@
    let o = new EventTarget(),
      s = new kd(),

--- a/patches/webview-remove-csp.patch
+++ b/patches/webview-remove-csp.patch
@@ -3,7 +3,7 @@
 @@ -130,10 +130,6 @@
        href="./assets/path-browserify-fgDTXxoN.js"
      />
-     <link rel="modulepreload" crossorigin href="./assets/src-CqhfAN-Y.js" />
+     <link rel="modulepreload" crossorigin href="./assets/src-CVmnixyG.js" />
 -    <meta
 -      http-equiv="Content-Security-Policy"
 -      content="default-src &#39;none&#39;; img-src &#39;self&#39; app: blob: data: https:; child-src &#39;self&#39; blob: https://*.web-sandbox.oaiusercontent.com https://web-sandbox.oaiusercontent.com; frame-src &#39;self&#39; blob: https://*.web-sandbox.oaiusercontent.com https://web-sandbox.oaiusercontent.com; worker-src &#39;self&#39; blob:; script-src &#39;self&#39; &#39;sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=&#39; &#39;wasm-unsafe-eval&#39;; style-src &#39;self&#39; &#39;unsafe-inline&#39;; font-src &#39;self&#39; data:; media-src &#39;self&#39; app: blob: data:; connect-src &#39;self&#39; https://ab.chatgpt.com https://cdn.openai.com;"

--- a/patches/webview-style.patch
+++ b/patches/webview-style.patch
@@ -5,6 +5,6 @@
        }
      </style>
 +    <style>.main-surface { --spacing-token-safe-header-left: 0px; }</style>
-     <script type="module" crossorigin src="./assets/index-CN-by6ks.js"></script>
+     <script type="module" crossorigin src="./assets/index-BCyxq2Zd.js"></script>
      <link
        rel="modulepreload"

--- a/patches/webview-thread-title.patch
+++ b/patches/webview-thread-title.patch
@@ -1,20 +1,20 @@
---- a/webview/assets/local-conversation-thread-CSj0yZak.js
-+++ b/webview/assets/local-conversation-thread-CSj0yZak.js
-@@ -151,6 +151,7 @@
-   n as Vt,
-   na as Ht,
-   ni as Ut,
+--- a/webview/assets/local-conversation-thread-C4DDoT1D.js
++++ b/webview/assets/local-conversation-thread-C4DDoT1D.js
+@@ -150,6 +150,7 @@
+   n as Bt,
+   na as Vt,
+   ni as Ht,
 +  nt as codexHostedWindowTitleAtom,
-   or as Wt,
-   p as Gt,
-   pt as Kt,
+   or as Ut,
+   p as Wt,
+   pt as Gt,
 @@ -34533,6 +34534,7 @@
-     f = $r($e, e),
-     p = $r(qt, e) ?? `needs_resume`,
-     m = $r(an, e),
-+    codexHostedWindowTitle = $r(codexHostedWindowTitleAtom, e),
-     h = $r(Tt, e) === `projectless`,
-     g = $r(It, e),
+     f = Qr(Qe, e),
+     p = Qr(Kt, e) ?? `needs_resume`,
+     m = Qr(rn, e),
++    codexHostedWindowTitle = Qr(codexHostedWindowTitleAtom, e),
+     h = Qr(wt, e) === `projectless`,
+     g = Qr(Ft, e),
      {
 @@ -34555,6 +34557,10 @@
    (0, Q.useEffect)(() => {
@@ -24,6 +24,6 @@
 +    let t = codexHostedWindowTitle?.trim();
 +    t && (document.title = `${t} | Codex`);
 +  }, [codexHostedWindowTitle]);
-   let F = wi(),
+   let F = Ci(),
      { agentMode: I } = eo({ conversationId: e, hostId: f }),
      L = d ? x(d) : null,

--- a/patches/webview-use-atfs-for-local-files.patch
+++ b/patches/webview-use-atfs-for-local-files.patch
@@ -1,5 +1,5 @@
---- a/webview/assets/filesystem-media-src-Bu6KQhIO.js
-+++ b/webview/assets/filesystem-media-src-Bu6KQhIO.js
+--- a/webview/assets/filesystem-media-src-BUaJcbAJ.js
++++ b/webview/assets/filesystem-media-src-BUaJcbAJ.js
 @@ -2,7 +2,7 @@
  var n = `app://fs`,
    r = `/@fs`;

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 TEMP_DIR="$(mktemp -d)"
 
-APP_VERSION="26.506.20924"
+APP_VERSION="26.506.31421"
 curl -o "$TEMP_DIR/file.zip" "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-$APP_VERSION.zip"
 
 HOSTED_CODEX_APP_ZIP="$TEMP_DIR/file.zip" bash ./scripts/prepare_asar


### PR DESCRIPTION
## Summary
- upgrade Codex Desktop to 26.506.31421
- update the bundled codex CLI pin to 0.130.0-alpha.5
- regenerate the affected asar patches against the new upstream asset files

## Validation
- `DEV=1 nix develop --command yarn run prepare:asar`
- validated regenerated patches by comparing the prepared tree against the hand-ported patched tree
- validated the server on port 8215 because 8214 was already in use locally
- loaded the client successfully with no error dialog or long loading hang

## Notes
Observed non-blocking validation warnings: Statsig network/403 console errors, a manifest enctype warning, unsupported `workspace_dependencies` feature enablement, and a native hotkey registration warning for `DoubleCommand`.
