### PR TITLE
[codex] Upgrade Codex Desktop to 26.519.41501

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,10 +16,10 @@ flake-utils.lib.eachSystem systems (
   system:
   let
     pkgs = import nixpkgs { inherit system; };
-    appVersion = "26.513.20950";
+    appVersion = "26.519.41501";
     codexZip = pkgs.fetchurl {
       url = "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-${appVersion}.zip";
-      hash = "sha256-zSlRaoUJc4eRFbe08qS/oyqaBbfW2Epjj3hlbEmA6Cw=";
+      hash = "sha256-fkavWDc7ms95kpa4Pnw88ZpSVdJjswy0N7SVw16WKL0=";
     };
     codex = self.packages.${system}.codex;
   in

--- a/nix/codex/default.nix
+++ b/nix/codex/default.nix
@@ -15,24 +15,24 @@ flake-utils.lib.eachSystem systems (
   system:
   let
     pkgs = import nixpkgs { inherit system; };
-    version = "0.131.0-alpha.9";
+    version = "0.133.0-alpha.1";
     platform =
       {
         aarch64-darwin = {
           npm = "darwin-arm64";
-          hash = "sha256-wUuans8qSISGW2tNXZBiEYL22X1qKSdvq8HD3WQtHEk=";
+          hash = "sha256-AoBexHTMnNWO2+3Z3fekiLIcsr51e434khvgFHQ+P5U=";
         };
         x86_64-darwin = {
           npm = "darwin-x64";
-          hash = "sha256-fuE3xe0Z1rJ3+8b86yZJckyImXftqXsJAxXsj/szZig=";
+          hash = "sha256-oL7Tq8pqppbbOHVbdP2co48BLBJx21CvDH5KAifDeKs=";
         };
         aarch64-linux = {
           npm = "linux-arm64";
-          hash = "sha256-WUjSGScE00q4YfdLLlHDW4ekYRcEhWvCX4eAytVtemU=";
+          hash = "sha256-rI1S/Okx15TBCUzSs0GNbV+VtZobsHh+sKTArWgF6SM=";
         };
         x86_64-linux = {
           npm = "linux-x64";
-          hash = "sha256-GSIUcJhlsNeqETh17af5s3xa01LVkWVW2GQH6P2WtLo=";
+          hash = "sha256-Wid3ZdMzb45vqNzuFtSV6LXnkDm7z/xk7xDvdresa2k=";
         };
       }
       .${system};

--- a/patches/sentry-disable-shell.patch
+++ b/patches/sentry-disable-shell.patch
@@ -1,20 +1,20 @@
---- a/.vite/build/workspace-root-drop-handler-D1HnRjoH.js
-+++ b/.vite/build/workspace-root-drop-handler-D1HnRjoH.js
-@@ -39485,6 +39485,7 @@
-     i = e.y(n.version);
+--- a/.vite/build/workspace-root-drop-handler-Bom6Z7sW.js
++++ b/.vite/build/workspace-root-drop-handler-Bom6Z7sW.js
+@@ -48232,6 +48232,7 @@
+     i = e.L(n.version);
    return (
      e.r({
 +      enabled: !1,
-       dsn: e.v,
-       environment: vA.buildFlavor,
+       dsn: e.I,
+       environment: QF.buildFlavor,
        release: i,
 --- a/.vite/build/worker.js
 +++ b/.vite/build/worker.js
-@@ -66670,6 +66670,7 @@
-   let n = kU(e.appVersion),
+@@ -74069,6 +74069,7 @@
+   let n = QV(e.appVersion),
      r = e.buildFlavor !== `prod`;
-   (DA({
+   (bk({
 +    enabled: !1,
-     dsn: jK,
+     dsn: aG,
      environment: e.buildFlavor,
-     release: MK(n.version),
+     release: oG(n.version),

--- a/patches/sentry-disable-webview.patch
+++ b/patches/sentry-disable-webview.patch
@@ -1,10 +1,10 @@
---- a/webview/assets/apps-Au-fp4y1.js
-+++ b/webview/assets/apps-Au-fp4y1.js
-@@ -30402,6 +30402,7 @@
-     n = ne(e.appVersion),
-     r = e.buildFlavor !== `prod`;
-   (Yw({
+--- a/webview/assets/error-boundary-CVsORXBJ.js
++++ b/webview/assets/error-boundary-CVsORXBJ.js
+@@ -7591,6 +7591,7 @@
+     s = i(e.appVersion),
+     c = e.buildFlavor !== `prod`;
+   (wf({
 +    enabled: !1,
-     dsn: re,
-     environment: Qw,
-     release: w(n.version),
+     beforeSend: o,
+     dsn: r,
+     environment: Ef,

--- a/patches/webview-electron-shim-close-sidebar.patch
+++ b/patches/webview-electron-shim-close-sidebar.patch
@@ -1,34 +1,33 @@
---- a/webview/assets/settings-back-route-C5YW47j2.js
-+++ b/webview/assets/settings-back-route-C5YW47j2.js
-@@ -1,5 +1,6 @@
+--- a/webview/assets/settings-back-route-Cfgk-CZa.js
++++ b/webview/assets/settings-back-route-Cfgk-CZa.js
+@@ -1,4 +1,5 @@
+-import { t as e } from "./jsx-runtime-CiQ1k8xo.js";
 +import { s as g } from "./chunk-Bj-mKKzh.js";
- import { Gn as e, Qn as t } from "./apps-Au-fp4y1.js";
--import { t as n } from "./jsx-runtime-Bj4hVTj7.js";
-+import { n as _, t as n } from "./jsx-runtime-Bj4hVTj7.js";
- import { t as r } from "./clsx-Duxel1Jl.js";
++import { n as _, t as e } from "./jsx-runtime-CiQ1k8xo.js";
+ import { t } from "./clsx-DDuZWq6Y.js";
  import {
-   J as i,
+   S as n,
 @@ -9,7 +10,8 @@
-   y as c,
- } from "./vscode-api-DH_DWhkY.js";
- import { t as l } from "./badge-0UPLZdLW.js";
--var u = s();
-+var u = s(),
+ } from "./setting-storage-EK1Te68s.js";
+ import { _ as s, c } from "./app-shell-state-HP0T5lEX.js";
+ import { t as l } from "./badge-DKQnFpmt.js";
+-var u = o();
++var u = o(),
 +  v = g(_());
  function d() {
-   let n = (0, u.c)(3),
-     r = o(a),
+   let e = (0, u.c)(3),
+     t = r(n),
 @@ -24,7 +26,12 @@
-       (n[0] = r),
-       (n[1] = i),
-       (n[2] = s)),
--    c(`toggle-sidebar`, i, s));
-+    c(`toggle-sidebar`, i, s),
+       (e[0] = t),
+       (e[1] = a),
+       (e[2] = o)),
+-    i(`toggle-sidebar`, a, o));
++    i(`toggle-sidebar`, a, o),
 +    v.useEffect(() => {
 +      window.__ELECTRON_SHIM__.closeSidebar = () => {
-+        t(r, !1);
++        s(t, !1);
 +      };
-+    }, [r]));
++    }, [t]));
  }
- var f = n();
+ var f = e();
  function p(e) {

--- a/patches/webview-initial-route.patch
+++ b/patches/webview-initial-route.patch
@@ -1,5 +1,5 @@
---- a/webview/assets/chunk-LFPYN7LY-CRkYzDF0.js
-+++ b/webview/assets/chunk-LFPYN7LY-CRkYzDF0.js
+--- a/webview/assets/chunk-LFPYN7LY-CkfOxD5s.js
++++ b/webview/assets/chunk-LFPYN7LY-CkfOxD5s.js
 @@ -1058,11 +1058,16 @@
    unstable_useTransitions: o,
  }) {
@@ -18,16 +18,16 @@
          o === !1 ? u(e) : r.startTransition(() => u(e));
        },
        [o],
---- a/webview/assets/apps-Au-fp4y1.js
-+++ b/webview/assets/apps-Au-fp4y1.js
-@@ -2058,8 +2058,8 @@
-   if (e == null) throw Error(`AppShellLayoutMotionContext is missing`);
-   return e;
- }
--var Yi = j(M, !0),
--  Xi = j(M, () => new Jt(1)),
-+var Yi = j(M, window.__ELECTRON_SHIM__.initialSidebarState),
-+  Xi = j(M, () => new Jt(window.__ELECTRON_SHIM__.initialSidebarState)),
-   Zi = j(F, !1),
-   Qi = j(F, () => new Jt(0)),
-   $i = j(F, !1),
+--- a/webview/assets/app-shell-state-HP0T5lEX.js
++++ b/webview/assets/app-shell-state-HP0T5lEX.js
+@@ -543,8 +543,8 @@
+   ut = ot.entries$,
+   dt = { center: rt, left: it, right: at },
+   ft = `app-shell-bottom-panel-launcher-visible`,
+-  pt = c(o, !0),
+-  mt = c(o, () => new g(1)),
++  pt = c(o, window.__ELECTRON_SHIM__.initialSidebarState),
++  mt = c(o, () => new g(window.__ELECTRON_SHIM__.initialSidebarState)),
+   ht = t(ft, !0),
+   gt = c(l, !1),
+   _t = c(l, () => new g(0)),

--- a/patches/webview-initial-route.patch
+++ b/patches/webview-initial-route.patch
@@ -27,7 +27,7 @@
 -  pt = c(o, !0),
 -  mt = c(o, () => new g(1)),
 +  pt = c(o, window.__ELECTRON_SHIM__.initialSidebarState),
-+  mt = c(o, () => new g(window.__ELECTRON_SHIM__.initialSidebarState)),
++  mt = c(o, () => new g(window.__ELECTRON_SHIM__.initialSidebarState ? 1 : 0)),
    ht = t(ft, !0),
    gt = c(l, !1),
    _t = c(l, () => new g(0)),

--- a/patches/webview-prompt-search-param.patch
+++ b/patches/webview-prompt-search-param.patch
@@ -1,100 +1,189 @@
---- a/webview/assets/app-main-Dsg36Y4q.js
-+++ b/webview/assets/app-main-Dsg36Y4q.js
-@@ -711,6 +711,7 @@
-   c as ri,
-   d as ii,
-   f as ai,
-+  h as useSearchParams,
-   i as oi,
-   l as si,
-   n as ci,
-@@ -22270,6 +22271,8 @@
-     p = ss(),
-     m = ai(),
-     h = pi(),
-+    [searchParams] = useSearchParams(),
-+    searchParamsPrompt = searchParams.get(`prompt`),
-     g = h.state;
-   Fw({
-     hostId: i,
-@@ -22570,6 +22573,8 @@
-                                       aboveComposerContent: te,
-                                       browserConversationId: j,
+--- a/webview/assets/app-main-DG-Mf4Wj.js
++++ b/webview/assets/app-main-DG-Mf4Wj.js
+@@ -874,6 +874,7 @@
+   c as mi,
+   d as hi,
+   f as gi,
++  h as __codexUseSearchParams,
+   i as _i,
+   l as vi,
+   n as yi,
+@@ -19778,6 +19779,8 @@
+     { data: p } = Ua(),
+     m = gi(),
+     h = wi(),
++    [__codexSearchParams] = __codexUseSearchParams(),
++    __codexSearchParamsPrompt = __codexSearchParams.get(`prompt`),
+     g = h.state,
+     { data: _ } = ii(`account-info`, {
+       queryConfig: { enabled: c === `chatgpt` },
+@@ -20156,6 +20159,10 @@
+                                       aboveComposerContent: pe,
+                                       browserConversationId: U,
                                        canStartRealtimeConversation: !0,
-+                                      defaultText: searchParamsPrompt ?? void 0,
-+                                      initialPrompt: searchParamsPrompt ?? void 0,
-                                       onLocalConversationCreated: N,
++                                      defaultText:
++                                        __codexSearchParamsPrompt ?? void 0,
++                                      initialPrompt:
++                                        __codexSearchParamsPrompt ?? void 0,
+                                       onLocalConversationCreated: te,
                                        externalFooterVariant: `home`,
-                                       showExternalFooter: se,
-@@ -22603,6 +22608,8 @@
-                         browserConversationId: j,
+                                       showExternalFooter: ye,
+@@ -20190,6 +20197,8 @@
+                         browserConversationId: U,
                          canStartRealtimeConversation: !0,
                          composerLayoutMode: `auto-single-line`,
-+                        defaultText: searchParamsPrompt ?? void 0,
-+                        initialPrompt: searchParamsPrompt ?? void 0,
-                         onLocalConversationCreated: N,
++                        defaultText: __codexSearchParamsPrompt ?? void 0,
++                        initialPrompt: __codexSearchParamsPrompt ?? void 0,
+                         onLocalConversationCreated: te,
+                         showExternalFooter: !R,
                          showWorkspaceDropdownInFooter: !1,
-                         hideRunLocationDropdownOverride: C.kind !== `git`,
---- a/webview/assets/composer-CL8HPtlL.js
-+++ b/webview/assets/composer-CL8HPtlL.js
-@@ -67407,6 +67407,7 @@
-   showPlanKeywordSuggestion: f,
-   composerModeAvailability: m,
-   placeholderText: h,
+--- a/webview/assets/composer-D0cvMZjq.js
++++ b/webview/assets/composer-D0cvMZjq.js
+@@ -20739,6 +20739,7 @@
+   showPlanKeywordSuggestion: h,
+   composerModeAvailability: g,
+   placeholderText: _,
 +  initialPrompt,
-   composerLayoutMode: _,
-   hotkeyWindowHomeFooterControls: v,
-   onSubmitLocal: y,
-@@ -67859,7 +67860,14 @@
-       (sn && ci(sn),
-         rn && ha(rn),
-         ga != null && da(ga),
--        nn && nn !== An.getText() && An.setPromptText(nn),
-+        nn && nn !== An.getText()
-+          ? An.setPromptText(nn)
-+          : !nn &&
+   composerLayoutMode: v,
+   hotkeyWindowHomeFooterControls: y,
+   onSubmitLocal: w,
+@@ -21189,7 +21190,14 @@
+       (Mr && wa(Mr),
+         kr && ho(kr),
+         go != null && fo(go),
+-        Dr && Dr !== X.getText() && X.setPromptText(Dr),
++        Dr && Dr !== X.getText()
++          ? X.setPromptText(Dr)
++          : !Dr &&
 +              initialPrompt != null &&
 +              initialPrompt !== `` &&
-+              An.getText() === ``
-+            ? An.setPromptText(initialPrompt)
++              X.getText() === ``
++            ? X.setPromptText(initialPrompt)
 +            : null,
-         an != null &&
-           an.length > 0 &&
-           ji((e) => {
-@@ -67877,7 +67885,7 @@
+         Ar != null &&
+           Ar.length > 0 &&
+           Ia((e) => {
+@@ -21207,7 +21215,7 @@
      });
-   (0, $.useEffect)(() => {
-     ba();
--  }, [nn, rn, an, on, ga]);
-+  }, [nn, rn, an, on, ga, initialPrompt]);
-   let [xa, Sa] = Ai(`composer_prefill`),
-     wa = (0, $.useEffectEvent)(() => {
-       let e = xa?.commentAttachments;
-@@ -69778,6 +69786,8 @@
-   hideRunLocationDropdownOverride: v = !1,
-   composerModeAvailability: y,
-   placeholderText: b,
-+  defaultText,
-+  initialPrompt,
-   composerLayoutMode: x = `multiline`,
-   hotkeyWindowHomeFooterControls: S,
-   lockedCollaborationMode: C,
-@@ -70056,8 +70066,8 @@
-       (0, Q.jsxs)(
-         FG,
-         {
--          defaultText: M,
--          defaultTextKind: nd(M) ? `prompt` : `plain`,
-+          defaultText: defaultText ?? M,
-+          defaultTextKind: nd(defaultText ?? M) ? `prompt` : `plain`,
-           children: [
-             S == null && n && r === `floating`
-               ? (0, Q.jsx)(`div`, {
-@@ -70090,6 +70100,7 @@
-               showPlanKeywordSuggestion: g,
-               composerModeAvailability: y,
-               placeholderText: b,
-+              initialPrompt,
-               composerLayoutMode: x,
-               hotkeyWindowHomeFooterControls: S,
-               surfaceClassName: c,
+   (0, Z.useEffect)(() => {
+     vo();
+-  }, [Dr, kr, Ar, jr, go]);
++  }, [Dr, kr, Ar, jr, go, initialPrompt]);
+   let [yo, bo] = ut(`composer_prefill`),
+     xo = (0, Z.useEffectEvent)(() => {
+       let e = yo?.commentAttachments;
+@@ -23253,7 +23261,7 @@
+   );
+ }
+ function ey(e) {
+-  let t = (0, $.c)(91),
++  let t = (0, $.c)(93),
+     {
+       browserConversationId: n,
+       className: r,
+@@ -23275,6 +23283,8 @@
+       hideRunLocationDropdownOverride: y,
+       composerModeAvailability: b,
+       placeholderText: x,
++      defaultText,
++      initialPrompt,
+       composerLayoutMode: S,
+       hotkeyWindowHomeFooterControls: w,
+       lockedCollaborationMode: T,
+@@ -23468,7 +23478,7 @@
+       (t[43] = Me),
+       (t[44] = Ne));
+   let Pe = $v,
+-    Fe = Nn(V) ? `prompt` : `plain`,
++    Fe = Nn(defaultText ?? V) ? `prompt` : `plain`,
+     Ie;
+   t[45] !== i || t[46] !== D || t[47] !== w
+     ? ((Ie =
+@@ -23518,7 +23528,8 @@
+   t[74] !== u ||
+   t[75] !== Le ||
+   t[76] !== Re ||
+-  t[77] !== ze
++  t[77] !== ze ||
++  t[78] !== initialPrompt
+     ? ((Be = (0, Q.jsx)(Xv, {
+         aboveComposerHeaderContent: Le,
+         activeCollaborationMode: ge,
+@@ -23540,6 +23551,7 @@
+         showPlanKeywordSuggestion: F,
+         composerModeAvailability: b,
+         placeholderText: x,
++        initialPrompt,
+         composerLayoutMode: ee,
+         hotkeyWindowHomeFooterControls: w,
+         surfaceClassName: u,
+@@ -23579,38 +23591,45 @@
+       (t[75] = Le),
+       (t[76] = Re),
+       (t[77] = ze),
+-      (t[78] = Be))
+-    : (Be = t[78]);
++      (t[78] = initialPrompt),
++      (t[79] = Be))
++    : (Be = t[79]);
+   let Ve;
+-  t[79] !== Pe ||
+-  t[80] !== B ||
+-  t[81] !== V ||
+-  t[82] !== Fe ||
+-  t[83] !== Ie ||
+-  t[84] !== Be
++  t[80] !== Pe ||
++  t[81] !== B ||
++  t[82] !== defaultText ||
++  t[83] !== V ||
++  t[84] !== Fe ||
++  t[85] !== Ie ||
++  t[86] !== Be
+     ? ((Ve = (0, Q.jsxs)(
+         Pe,
+-        { defaultText: V, defaultTextKind: Fe, children: [Ie, Be] },
++        {
++          defaultText: defaultText ?? V,
++          defaultTextKind: Fe,
++          children: [Ie, Be],
++        },
+         B,
+       )),
+-      (t[79] = Pe),
+-      (t[80] = B),
+-      (t[81] = V),
+-      (t[82] = Fe),
+-      (t[83] = Ie),
+-      (t[84] = Be),
+-      (t[85] = Ve))
+-    : (Ve = t[85]);
++      (t[80] = Pe),
++      (t[81] = B),
++      (t[82] = defaultText),
++      (t[83] = V),
++      (t[84] = Fe),
++      (t[85] = Ie),
++      (t[86] = Be),
++      (t[87] = Ve))
++    : (Ve = t[87]);
+   let He;
+   return (
+-    t[86] !== ke || t[87] !== je || t[88] !== Ne || t[89] !== Ve
++    t[88] !== ke || t[89] !== je || t[90] !== Ne || t[91] !== Ve
+       ? ((He = (0, Q.jsxs)(`div`, { className: ke, children: [je, Ne, Ve] })),
+-        (t[86] = ke),
+-        (t[87] = je),
+-        (t[88] = Ne),
+-        (t[89] = Ve),
+-        (t[90] = He))
+-      : (He = t[90]),
++        (t[88] = ke),
++        (t[89] = je),
++        (t[90] = Ne),
++        (t[91] = Ve),
++        (t[92] = He))
++      : (He = t[92]),
+     He
+   );
+ }

--- a/patches/webview-prosemirror-inputmode.patch
+++ b/patches/webview-prosemirror-inputmode.patch
@@ -1,8 +1,8 @@
---- a/webview/assets/prosemirror-DbRBBq50.js
-+++ b/webview/assets/prosemirror-DbRBBq50.js
-@@ -25553,6 +25553,13 @@
+--- a/webview/assets/prompt-editor-dZKGftNt.js
++++ b/webview/assets/prompt-editor-dZKGftNt.js
+@@ -19898,6 +19898,13 @@
    let o = new EventTarget(),
-     s = new Sp(),
+     s = new Bc(),
      c = a,
 +    inputModeDisabled = !1,
 +    getAttributes = () => (inputModeDisabled ? {} : { inputmode: `none` }),
@@ -11,12 +11,12 @@
 +        ((inputModeDisabled = e),
 +        l.isDestroyed || l.setProps({ attributes: getAttributes }));
 +    },
-     l = new of(null, {
-       state: zi.create({
-         schema: yp,
-@@ -25635,6 +25642,18 @@
+     l = new Ws(null, {
+       state: Ee.create({
+         schema: zc,
+@@ -19980,6 +19987,18 @@
          let t = l.state.apply(e);
-         (l.updateState(t), o.dispatchEvent(new Event(Ki)));
+         (l.updateState(t), o.dispatchEvent(new Event(we)));
        },
 +      attributes: getAttributes,
 +      handleDOMEvents: {

--- a/patches/webview-remove-csp.patch
+++ b/patches/webview-remove-csp.patch
@@ -3,7 +3,7 @@
 @@ -125,10 +125,6 @@
      />
      <link rel="modulepreload" crossorigin href="./assets/chunk-Bj-mKKzh.js" />
-     <link rel="modulepreload" crossorigin href="./assets/src-CdfxiY-T.js" />
+     <link rel="modulepreload" crossorigin href="./assets/src-DAzAmbVS.js" />
 -    <meta
 -      http-equiv="Content-Security-Policy"
 -      content="default-src &#39;none&#39;; img-src &#39;self&#39; app: blob: data: https:; child-src &#39;self&#39; blob: https://*.web-sandbox.oaiusercontent.com https://web-sandbox.oaiusercontent.com; frame-src &#39;self&#39; blob: https://*.web-sandbox.oaiusercontent.com https://web-sandbox.oaiusercontent.com; worker-src &#39;self&#39; blob:; script-src &#39;self&#39; &#39;sha256-Z2/iFzh9VMlVkEOar1f/oSHWwQk3ve1qk/C2WdsC4Xk=&#39; &#39;wasm-unsafe-eval&#39;; style-src &#39;self&#39; &#39;unsafe-inline&#39;; font-src &#39;self&#39; data:; media-src &#39;self&#39; app: blob: data:; connect-src &#39;self&#39; https://ab.chatgpt.com https://cdn.openai.com;"

--- a/patches/webview-style.patch
+++ b/patches/webview-style.patch
@@ -9,6 +9,6 @@
 +        --spacing-token-safe-header-left: 0px;
 +      }
 +    </style>
-     <script type="module" crossorigin src="./assets/index-DxnGmFpS.js"></script>
+     <script type="module" crossorigin src="./assets/index-DCUkNxRU.js"></script>
      <link
        rel="modulepreload"

--- a/patches/webview-thread-title.patch
+++ b/patches/webview-thread-title.patch
@@ -1,29 +1,21 @@
---- a/webview/assets/local-conversation-thread-Dki9vHa8.js
-+++ b/webview/assets/local-conversation-thread-Dki9vHa8.js
-@@ -148,6 +148,7 @@
-   m as Bt,
-   ma as Vt,
-   mt as Ht,
-+  st as codexHostedWindowTitleAtom,
-   n as Ut,
-   on as Wt,
-   ot as Gt,
-@@ -34173,6 +34174,7 @@
-     h = xr(wt, e) ?? `needs_resume`,
-     g = xr(Gt, e),
-     _ = xr(Kt, e),
-+    codexHostedWindowTitle = xr(codexHostedWindowTitleAtom, e),
-     v = xr(Ht, e) === `projectless`,
-     y = xr(lt, e),
+--- a/webview/assets/local-conversation-thread-CecHj6JI.js
++++ b/webview/assets/local-conversation-thread-CecHj6JI.js
+@@ -29909,6 +29909,7 @@
+     y = Mt(nt, e),
+     b = Mt(ht, e) === `projectless`,
+     x = Mt(W, e),
++    codexHostedWindowTitle = Mt(pt, e),
      {
-@@ -34196,6 +34198,10 @@
+       hasInheritedParentTurns: S,
+       hasRenderableTurns: C,
+@@ -29930,6 +29931,10 @@
    (0, Q.useEffect)(() => {
-     I?.id == null || I.readAt != null || F(I.id);
-   }, [I?.id, I?.readAt, F]);
+     z?.id == null || z.readAt != null || L(z.id);
+   }, [z?.id, z?.readAt, L]);
 +  (0, Q.useEffect)(() => {
 +    let t = codexHostedWindowTitle?.trim();
 +    t && (document.title = `${t} | Codex`);
 +  }, [codexHostedWindowTitle]);
-   let z = li(),
-     { agentMode: B } = Ka({ conversationId: e, hostId: m }),
-     V = p ? P(p) : null,
+   let H = zt(),
+     { agentMode: U } = qn({ conversationId: e, hostId: g }),
+     te = h ? r(h) : null,

--- a/patches/webview-use-atfs-for-local-files.patch
+++ b/patches/webview-use-atfs-for-local-files.patch
@@ -1,5 +1,5 @@
---- a/webview/assets/filesystem-media-src-BngrzgPI.js
-+++ b/webview/assets/filesystem-media-src-BngrzgPI.js
+--- a/webview/assets/filesystem-media-src-CSSK5uhc.js
++++ b/webview/assets/filesystem-media-src-CSSK5uhc.js
 @@ -2,7 +2,7 @@
  var n = `app://fs`,
    r = `/@fs`;

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 TEMP_DIR="$(mktemp -d)"
 
-APP_VERSION="26.513.20950"
+APP_VERSION="26.519.41501"
 curl -o "$TEMP_DIR/file.zip" "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-$APP_VERSION.zip"
 
 HOSTED_CODEX_APP_ZIP="$TEMP_DIR/file.zip" bash ./scripts/prepare_asar


### PR DESCRIPTION
## Summary

- Upgrade hosted Codex Desktop from `26.513.20950` to `26.519.41501`.
- Update the bundled `codex` CLI derivation from `0.131.0-alpha.9` to `0.133.0-alpha.1` with refreshed platform hashes.
- Regenerate the webview and Sentry patch files for the new upstream asset names/layout.

## Notes

The latest local update was found at `/Volumes/data-lake/data-lake-1/codex-desktop-updates/versions/3044-26.519.41501`, with `version.xml` reporting build `3044`, short version `26.519.41501`, and publish date `Fri, 22 May 2026 16:29:41 -0700`.

During dev-server validation, the app loaded successfully. The terminal still showed existing local-dev warnings for `DoubleCommand` appshot hotkey registration and recommended-skills git lookup fallback, but the browser page loaded and reported no console errors.

## Validation

- `DEV=1 nix develop --command yarn run prepare:asar`
- patch sequence temp-applied against `scratch-new-version-unmodified/asar` and reproduced the generated patched files without `.orig` backups
- `nix develop --command yarn server`
- opened `http://localhost:8214/`; main Codex UI rendered and browser console error log remained empty after waiting
- `nix build --no-link .#default`
