### PR TITLE
Reject pending IPC requests on disconnect

### DIFF
--- a/src/browser/shim.ts
+++ b/src/browser/shim.ts
@@ -210,6 +210,33 @@ function flushOutboundQueue(): void {
   }
 }
 
+function removeQueuedRequest(requestId: string): void {
+  for (let index = outboundQueue.length - 1; index >= 0; index -= 1) {
+    const message = outboundQueue[index];
+    if (
+      (message.type === "ipc-renderer-invoke" ||
+        message.type === "workspace-directory-entries-request") &&
+      message.requestId === requestId
+    ) {
+      outboundQueue.splice(index, 1);
+    }
+  }
+}
+
+function rejectPendingRequests(reason: Error): void {
+  for (const [requestId, pending] of pendingInvokes) {
+    removeQueuedRequest(requestId);
+    pending.reject(reason);
+  }
+  pendingInvokes.clear();
+
+  for (const [requestId, pending] of pendingDirectoryEntries) {
+    removeQueuedRequest(requestId);
+    pending.reject(reason);
+  }
+  pendingDirectoryEntries.clear();
+}
+
 function scheduleReconnect(): void {
   if (reconnectTimeoutId !== null) {
     return;
@@ -229,13 +256,14 @@ function ensureSocket(): void {
     return;
   }
 
-  socket = new WebSocket(
+  const nextSocket = new WebSocket(
     `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/__backend/ipc`,
   );
-  socket.addEventListener("open", () => {
+  socket = nextSocket;
+  nextSocket.addEventListener("open", () => {
     flushOutboundQueue();
   });
-  socket.addEventListener("message", (event) => {
+  nextSocket.addEventListener("message", (event) => {
     try {
       const message = JSON.parse(String(event.data)) as MainToRendererMessage;
       handleIncomingMessage(message);
@@ -246,11 +274,18 @@ function ensureSocket(): void {
       );
     }
   });
-  socket.addEventListener("close", () => {
+  nextSocket.addEventListener("close", () => {
+    if (socket !== nextSocket) {
+      return;
+    }
+    socket = null;
+    rejectPendingRequests(
+      new Error("[ipc-bridge] connection closed before the request completed"),
+    );
     scheduleReconnect();
   });
-  socket.addEventListener("error", () => {
-    scheduleReconnect();
+  nextSocket.addEventListener("error", () => {
+    nextSocket.close();
   });
 }
 


### PR DESCRIPTION
## Summary

- reject pending renderer invokes and directory requests when their WebSocket disconnects
- remove queued request messages before reconnecting so stale operations are not sent later
- close errored sockets and guard against stale close events affecting a replacement connection

## Why

The browser bridge currently reconnects after a WebSocket closes, but promises for requests sent on the old connection remain pending forever. This leaves callers in a permanent loading state after transient proxy, network, or browser connection failures.

Requests that were still queued also survive reconnect and may execute after their callers have already moved on.

## Verification

- `npm run build:browser`
- `npm run build:server`
- `git diff --check`