### PR TITLE
Fix integrated terminal PTY on Linux

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -86,6 +86,52 @@ flake-utils.lib.eachSystem systems (
             runHook postInstall
           '';
         };
+        nodePtyNative = pkgs.stdenv.mkDerivation {
+          pname = "node-pty-native";
+          version = "1.1.0";
+          src = pkgs.lib.fileset.toSource {
+            root = ./.;
+            fileset = pkgs.lib.fileset.unions [
+              ./package.json
+              ./package-lock.json
+            ];
+          };
+
+          inherit npmDeps;
+
+          npmRebuildFlags = [ "--ignore-scripts" ];
+
+          nativeBuildInputs = [
+            pkgs.importNpmLock.npmConfigHook
+            pkgs.nodejs
+            pkgs.python3
+            pkgs.removeReferencesTo
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.cctools ];
+
+          buildPhase = ''
+            runHook preBuild
+
+            pushd node_modules/node-pty
+            npm_config_build_from_source=true \
+              npm_config_nodedir="${nodeSources}" \
+              npm run install --offline
+            chmod +x build/Release/spawn-helper
+            find build -type f -exec ${pkgs.lib.getExe pkgs.removeReferencesTo} -t "${nodeSources}" {} \;
+            popd
+
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+
+            mkdir -p "$out"
+            cp -R node_modules/node-pty/build "$out/build"
+
+            runHook postInstall
+          '';
+        };
       in
       {
         default = pkgs.buildNpmPackage {
@@ -110,7 +156,13 @@ flake-utils.lib.eachSystem systems (
 
           preBuild = ''
             patchShebangs scripts
+
+            addon="node_modules/node-pty"
+            rm -rf "$addon/build"
+            ln -s ${nodePtyNative}/build "$addon/build"
           '';
+
+          postBuild = "npm run test:pty";
 
           preInstall = ''
             # npm pack always runs the package prepare lifecycle. Nix already ran
@@ -137,6 +189,10 @@ flake-utils.lib.eachSystem systems (
             addon="$out/lib/node_modules/codex-web/node_modules/better-sqlite3"
             rm -rf "$addon/build"
             ln -s ${betterSqlite3Native}/build "$addon/build"
+
+            addon="$out/lib/node_modules/codex-web/node_modules/node-pty"
+            rm -rf "$addon/build"
+            ln -s ${nodePtyNative}/build "$addon/build"
           '';
 
           postFixup = ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "better-sqlite3": "^12.9.0",
         "fastify": "^5.8.5",
         "glob": "^13.0.6",
+        "node-pty": "^1.1.0",
         "prettier": "^3.8.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -3039,6 +3040,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/normalize-url": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.1",
   "files": [
     "README.md",
+    "scripts/ensure_node_pty_permissions.mjs",
+    "scripts/smoke_test_terminal_pty.mjs",
     "scratch/asar/**/*",
     "src/server/**/*.js",
     "src/server/electron/index.js",
@@ -14,12 +16,14 @@
     "build": "npm run prepare:asar && npm run build:browser && npm run build:server",
     "launch:unpacked:server": "http-server ./scratch/asar/webview -a localhost -p 5175 -c-1",
     "launch:unpacked": "NODE_ENV=development electron ./scratch/asar --remote-debugging-port=9222",
+    "postinstall": "node scripts/ensure_node_pty_permissions.mjs",
     "dev:browser": "vite --config vite.browser.config.ts",
     "build:browser": "vite build --config vite.browser.config.ts",
     "build:server": "cd src/server && tsc",
     "prepare:asar": "./scripts/prepare_asar",
     "preserver": "npm run build:server && npm run build:browser",
-    "server": "CODEX_CLI_PATH=$(which codex) node src/server/main.js"
+    "server": "CODEX_CLI_PATH=$(which codex) node src/server/main.js",
+    "test:pty": "node scripts/smoke_test_terminal_pty.mjs"
   },
   "repository": "git@github.com:0xcaff/codex-web.git",
   "author": "martin <martincharles07@gmail.com>",
@@ -33,6 +37,7 @@
     "better-sqlite3": "^12.9.0",
     "fastify": "^5.8.5",
     "glob": "^13.0.6",
+    "node-pty": "^1.1.0",
     "prettier": "^3.8.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/scripts/ensure_node_pty_permissions.mjs
+++ b/scripts/ensure_node_pty_permissions.mjs
@@ -1,0 +1,26 @@
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+
+const packageRequire = createRequire(path.resolve("package.json"));
+const nodePtyRoot = path.dirname(
+  packageRequire.resolve("node-pty/package.json"),
+);
+const helperCandidates = [
+  path.join(nodePtyRoot, "build/Release/spawn-helper"),
+  path.join(
+    nodePtyRoot,
+    `prebuilds/${process.platform}-${process.arch}/spawn-helper`,
+  ),
+];
+
+for (const helperPath of helperCandidates) {
+  try {
+    await fs.chmod(helperPath, 0o755);
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+}

--- a/scripts/prepare_asar
+++ b/scripts/prepare_asar
@@ -41,4 +41,9 @@ patch --batch --forward --strip 1 --directory scratch/asar < patches/webview-pro
 patch --batch --forward --strip 1 --directory scratch/asar < patches/preload-disable-device-check.patch
 patch --batch --forward --strip 1 --directory scratch/asar < patches/sentry-disable-shell.patch
 patch --batch --forward --strip 1 --directory scratch/asar < patches/sentry-disable-webview.patch
-rm -rf scratch/asar/node_modules/better-sqlite3
+# The downloaded desktop app is the macOS arm64 build, so its bundled native
+# modules cannot load on Linux. Resolve them from the Linux-native copies
+# installed in this package's node_modules directory instead.
+rm -rf \
+  scratch/asar/node_modules/better-sqlite3 \
+  scratch/asar/node_modules/node-pty

--- a/scripts/smoke_test_terminal_pty.mjs
+++ b/scripts/smoke_test_terminal_pty.mjs
@@ -1,0 +1,46 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import process from "node:process";
+
+const appBundleRequire = createRequire(
+  path.resolve("scratch/asar/.vite/build/main-terminal-smoke.js"),
+);
+const resolvedModule = appBundleRequire.resolve("node-pty");
+const bundledModuleDirectory = path.resolve(
+  "scratch/asar/node_modules/node-pty",
+);
+
+if (resolvedModule.startsWith(bundledModuleDirectory)) {
+  throw new Error(
+    `terminal resolved the bundled desktop node-pty module: ${resolvedModule}`,
+  );
+}
+
+const { spawn } = appBundleRequire("node-pty");
+const expectedOutput = "codex-web-terminal-pty-ok";
+const terminal = spawn("/bin/sh", ["-lc", `printf ${expectedOutput}`], {
+  cols: 80,
+  rows: 24,
+  cwd: "/tmp",
+  env: process.env,
+});
+
+let output = "";
+const timeout = setTimeout(() => {
+  terminal.kill();
+  throw new Error("terminal PTY smoke test timed out");
+}, 5_000);
+
+terminal.onData((data) => {
+  output += data;
+});
+
+terminal.onExit(({ exitCode, signal }) => {
+  clearTimeout(timeout);
+  if (exitCode !== 0 || !output.includes(expectedOutput)) {
+    throw new Error(
+      `terminal PTY smoke test failed: exit=${exitCode} signal=${signal} output=${JSON.stringify(output)}`,
+    );
+  }
+  console.log(`terminal PTY smoke test passed (${resolvedModule})`);
+});


### PR DESCRIPTION
## Summary

- install `node-pty` as a host-native dependency
- remove the incompatible macOS `node-pty` bundled in the downloaded desktop ASAR
- build and link `node-pty` for Nix packages
- preserve the spawn-helper executable bit for npm's prebuilt macOS package
- add a PTY smoke test that verifies resolution outside the bundled ASAR and executes a real shell through a pseudoterminal

## Why

The desktop archive is downloaded from the macOS arm64 build. Its bundled `node-pty` native module cannot load on Linux, so opening the integrated terminal fails. Resolving `node-pty` from the host installation provides a native module for the actual runtime platform.

## Validation

- `npm run prepare`
- `npm run build:browser`
- `npm run build:server`
- `npm run test:pty` on macOS
- clean packed npm install followed by `npm run test:pty`
- clean `linux/amd64` Node container install followed by `npm run test:pty`

This PR intentionally contains no Cloud Run, GCS, IAP, SSH, container deployment, or deployment-documentation changes.
