### PR TITLE
Support localhost OAuth callback handoff for hosted browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ server.
 codex login --device-auth
 ```
 
+### remote-control authorization
+
+remote-control setup opens an OpenAI authorization page whose registered
+callback points to `localhost`. when codex-web is hosted on another machine,
+the browser cannot reach that machine's loopback listener directly.
+
+codex-web displays a completion dialog for this flow. after OpenAI redirects
+to the localhost page, copy the complete URL from that tab's address bar and
+paste it into the dialog. the callback is validated and forwarded internally
+to the loopback listener; ports `1455` and `1457` do not need to be exposed.
+
+the callback contains a short-lived authorization code. do not paste it into a
+chat, log, shell command, or any page other than the completion dialog.
+
 ### proxying to app-server (advanced usage)
 
 it’s often useful to run the app server separately, so a crash or restart of
@@ -133,14 +147,14 @@ talk.
 
 ## alternatives
 
-* [davej/pocodex](https://github.com/davej/pocodex) i used this until the wheels fell off. i needed subagents
+- [davej/pocodex](https://github.com/davej/pocodex) i used this until the wheels fell off. i needed subagents
   and an inline image viewer. this didn't have them and was having a hard time
   keeping up with upstream codex updates.
-* the native codex remote feature (behind a feature flag) is great for
+- the native codex remote feature (behind a feature flag) is great for
   connecting to remote codex hosts over ssh to manage long running tasks but
   this only works if you have codex desktop on your client device. this means it
   doesn't work on mobile.
-* upcoming first party mobile app from openai. `codex-web` exists and works
+- upcoming first party mobile app from openai. `codex-web` exists and works
   today. i can't wait for the mobile app but judging by the other openai mobile
   apps, i'm a little bit skeptical about the quality of the mobile experience.
   time will tell.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "build:server": "cd src/server && tsc",
     "prepare:asar": "./scripts/prepare_asar",
     "preserver": "npm run build:server && npm run build:browser",
-    "server": "CODEX_CLI_PATH=$(which codex) node src/server/main.js"
+    "server": "CODEX_CLI_PATH=$(which codex) node src/server/main.js",
+    "test": "npm run build:server && npm run build:browser && node --test test/**/*.test.mjs"
   },
   "repository": "git@github.com:0xcaff/codex-web.git",
   "author": "martin <martincharles07@gmail.com>",

--- a/src/browser/oauth-callback-dialog.tsx
+++ b/src/browser/oauth-callback-dialog.tsx
@@ -1,0 +1,233 @@
+import React, { FormEvent, useEffect, useRef, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const DIALOG_ID = "codex-web-remote-control-oauth-dialog";
+const TITLE_ID = `${DIALOG_ID}-title`;
+const DESCRIPTION_ID = `${DIALOG_ID}-description`;
+
+type RemoteControlOAuthDialogProps = {
+  authorizationUrl: string;
+  onClose: () => void;
+  onSubmit: (callbackUrl: string) => Promise<void>;
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function isRemoteControlAuthorizationUrl(value: string): boolean {
+  let authorizationUrl: URL;
+  try {
+    authorizationUrl = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (
+    authorizationUrl.protocol !== "https:" ||
+    authorizationUrl.hostname !== "auth.openai.com" ||
+    authorizationUrl.pathname !== "/oauth/authorize" ||
+    authorizationUrl.username !== "" ||
+    authorizationUrl.password !== ""
+  ) {
+    return false;
+  }
+
+  const scopes = authorizationUrl.searchParams.get("scope")?.split(/\s+/u);
+  if (!scopes?.includes("codex.remote_control.enroll")) {
+    return false;
+  }
+
+  const redirectValue = authorizationUrl.searchParams.get("redirect_uri");
+  if (!redirectValue) {
+    return false;
+  }
+
+  try {
+    const redirectUrl = new URL(redirectValue);
+    return (
+      redirectUrl.protocol === "http:" &&
+      redirectUrl.hostname === "localhost" &&
+      new Set(["1455", "1457"]).has(redirectUrl.port) &&
+      redirectUrl.pathname === "/auth/callback" &&
+      redirectUrl.username === "" &&
+      redirectUrl.password === "" &&
+      redirectUrl.search === "" &&
+      redirectUrl.hash === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
+function RemoteControlOAuthDialog({
+  authorizationUrl,
+  onClose,
+  onSubmit,
+}: RemoteControlOAuthDialogProps): React.ReactElement {
+  const [callbackUrl, setCallbackUrl] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const authorizationLinkRef = useRef<HTMLAnchorElement | null>(null);
+
+  useEffect(() => {
+    authorizationLinkRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown, true);
+    return () => window.removeEventListener("keydown", handleKeyDown, true);
+  }, [onClose]);
+
+  async function handleSubmit(
+    event: FormEvent<HTMLFormElement>,
+  ): Promise<void> {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await onSubmit(callbackUrl.trim());
+      setCallbackUrl("");
+      onClose();
+    } catch (submitError) {
+      setError(errorMessage(submitError));
+      setIsSubmitting(false);
+    }
+  }
+
+  const stopPropagation = (event: React.SyntheticEvent): void => {
+    event.stopPropagation();
+  };
+
+  return (
+    <div
+      aria-describedby={DESCRIPTION_ID}
+      aria-labelledby={TITLE_ID}
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-6"
+      onClick={stopPropagation}
+      onFocus={stopPropagation}
+      onMouseDown={stopPropagation}
+      onPointerDown={stopPropagation}
+      role="dialog"
+      style={{ pointerEvents: "auto" }}
+    >
+      <form
+        className="bg-token-dropdown-background text-token-foreground ring-token-border w-full max-w-xl rounded-3xl p-6 shadow-lg ring-[0.5px]"
+        onSubmit={handleSubmit}
+      >
+        <h2 className="heading-dialog font-semibold" id={TITLE_ID}>
+          Complete remote-control authorization
+        </h2>
+        <p
+          className="text-token-text-secondary mt-2 text-sm leading-6"
+          id={DESCRIPTION_ID}
+        >
+          Open the authorization page, finish signing in, and copy the complete
+          localhost URL from the redirected tab. Return here and paste it below.
+          Do not paste the URL into chat.
+        </p>
+
+        <a
+          className="bg-token-foreground text-token-dropdown-background mt-4 inline-flex rounded-lg px-4 py-2 text-sm font-medium"
+          href={authorizationUrl}
+          ref={authorizationLinkRef}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          Open authorization page
+        </a>
+
+        <label className="mt-5 flex flex-col gap-2 text-sm font-medium">
+          OpenAI localhost callback URL
+          <textarea
+            autoComplete="off"
+            autoFocus={false}
+            className="border-token-input-border bg-token-input-background text-token-input-foreground min-h-28 rounded-lg border p-3 font-mono text-xs outline-none"
+            disabled={isSubmitting}
+            onChange={(event) => setCallbackUrl(event.target.value)}
+            placeholder="http://localhost:1455/auth/callback?code=…&state=…"
+            required
+            rows={4}
+            spellCheck={false}
+            value={callbackUrl}
+          />
+        </label>
+
+        {error ? (
+          <p aria-live="polite" className="mt-3 text-sm text-red-600">
+            {error}
+          </p>
+        ) : null}
+
+        <div className="mt-5 flex justify-end gap-3">
+          <button
+            className="border-token-border rounded-lg border px-4 py-2 text-sm"
+            disabled={isSubmitting}
+            onClick={onClose}
+            type="button"
+          >
+            Cancel
+          </button>
+          <button
+            className="bg-token-foreground text-token-dropdown-background rounded-lg px-4 py-2 text-sm font-medium disabled:opacity-50"
+            disabled={isSubmitting || callbackUrl.trim() === ""}
+            type="submit"
+          >
+            {isSubmitting ? "Completing…" : "Complete authorization"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+let activeRoot: Root | null = null;
+let activeHost: HTMLElement | null = null;
+
+function closeActiveDialog(): void {
+  activeRoot?.unmount();
+  activeHost?.remove();
+  activeRoot = null;
+  activeHost = null;
+}
+
+function createHost(): HTMLElement {
+  closeActiveDialog();
+
+  const host = document.createElement("div");
+  host.id = DIALOG_ID;
+  const dialogs = document.querySelectorAll<HTMLElement>(
+    '[role="dialog"][aria-modal="true"]',
+  );
+  const activeDialog = dialogs.item(dialogs.length - 1);
+  (activeDialog ?? document.body).append(host);
+  return host;
+}
+
+export function openRemoteControlOAuthDialog(
+  options: Omit<RemoteControlOAuthDialogProps, "onClose">,
+): void {
+  const activeElement = document.activeElement;
+  const host = createHost();
+  const root = createRoot(host);
+  activeHost = host;
+  activeRoot = root;
+
+  const close = (): void => {
+    closeActiveDialog();
+    if (activeElement instanceof HTMLElement) {
+      activeElement.focus();
+    }
+  };
+
+  root.render(<RemoteControlOAuthDialog {...options} onClose={close} />);
+}

--- a/src/browser/shim.ts
+++ b/src/browser/shim.ts
@@ -10,6 +10,10 @@ import {
   openSelectWorkspaceRootDialog,
   type WorkspaceDirectoryEntries,
 } from "./workspace-root-dialog";
+import {
+  isRemoteControlAuthorizationUrl,
+  openRemoteControlOAuthDialog,
+} from "./oauth-callback-dialog";
 
 type IpcListener = (event: unknown, ...args: unknown[]) => void;
 
@@ -45,6 +49,11 @@ type RendererToMainMessage =
       requestId: string;
       directoryPath: string | null;
       directoriesOnly: boolean;
+    }
+  | {
+      type: "oauth-callback-forward";
+      requestId: string;
+      callbackUrl: string;
     };
 
 type MainToRendererMessage =
@@ -85,6 +94,21 @@ type MainToRendererMessage =
   | {
       type: "message-port-close";
       portId: string;
+    }
+  | {
+      type: "oauth-callback-forward-result";
+      requestId: string;
+      ok: true;
+    }
+  | {
+      type: "oauth-callback-forward-result";
+      requestId: string;
+      ok: false;
+      errorMessage: string;
+    }
+  | {
+      type: "open-external";
+      url: string;
     };
 
 const RECONNECT_DELAY_MS = 1_000;
@@ -148,6 +172,13 @@ const pendingDirectoryEntries = new Map<
 >();
 const rendererListeners = new Map<string, Set<IpcListener>>();
 const messagePorts = new Map<string, MessagePort>();
+const pendingOAuthCallbacks = new Map<
+  string,
+  {
+    reject: (reason?: unknown) => void;
+    resolve: () => void;
+  }
+>();
 
 function unimplemented(method: string): never {
   debugger;
@@ -168,6 +199,25 @@ export function emitRendererEvent(channel: string, args: unknown[]): void {
 function handleIncomingMessage(message: MainToRendererMessage): void {
   if (message.type === "ipc-main-event") {
     emitRendererEvent(message.channel, message.args);
+    return;
+  }
+
+  if (message.type === "open-external") {
+    openExternalUrl(message.url);
+    return;
+  }
+
+  if (message.type === "oauth-callback-forward-result") {
+    const pending = pendingOAuthCallbacks.get(message.requestId);
+    if (!pending) {
+      return;
+    }
+    pendingOAuthCallbacks.delete(message.requestId);
+    if (message.ok) {
+      pending.resolve();
+      return;
+    }
+    pending.reject(new Error(message.errorMessage));
     return;
   }
 
@@ -261,6 +311,9 @@ function ensureSocket(): void {
       port.close();
     }
     messagePorts.clear();
+    rejectPendingOAuthCallbacks(
+      new Error("The Codex Web connection closed during authorization"),
+    );
     scheduleReconnect();
   });
   socket.addEventListener("error", () => {
@@ -272,6 +325,18 @@ function enqueueMessage(message: RendererToMainMessage): void {
   outboundQueue.push(message);
   ensureSocket();
   flushOutboundQueue();
+}
+
+function rejectPendingOAuthCallbacks(error: Error): void {
+  for (const pending of pendingOAuthCallbacks.values()) {
+    pending.reject(error);
+  }
+  pendingOAuthCallbacks.clear();
+  for (let index = outboundQueue.length - 1; index >= 0; index -= 1) {
+    if (outboundQueue[index]?.type === "oauth-callback-forward") {
+      outboundQueue.splice(index, 1);
+    }
+  }
 }
 
 function nextRequestId(): string {
@@ -346,6 +411,43 @@ function requestWorkspaceDirectoryEntries(
       directoriesOnly: true,
     });
   });
+}
+
+function forwardRemoteControlOAuthCallback(callbackUrl: string): Promise<void> {
+  const requestId = nextRequestId();
+  return new Promise((resolve, reject) => {
+    pendingOAuthCallbacks.set(requestId, { reject, resolve });
+    enqueueMessage({
+      type: "oauth-callback-forward",
+      requestId,
+      callbackUrl,
+    });
+  });
+}
+
+function openExternalUrl(value: string): void {
+  let externalUrl: URL;
+  try {
+    externalUrl = new URL(value);
+  } catch {
+    throw new Error("[electron-stub] refusing invalid external URL");
+  }
+  if (!new Set(["http:", "https:"]).has(externalUrl.protocol)) {
+    throw new Error(
+      `[electron-stub] refusing external URL protocol ${externalUrl.protocol}`,
+    );
+  }
+
+  const url = externalUrl.toString();
+  if (isRemoteControlAuthorizationUrl(url)) {
+    openRemoteControlOAuthDialog({
+      authorizationUrl: url,
+      onSubmit: forwardRemoteControlOAuthCallback,
+    });
+    return;
+  }
+
+  window.open(url, "_blank", "noopener,noreferrer");
 }
 
 const themeMediaQuery = matchMedia("(prefers-color-scheme: dark)");
@@ -427,7 +529,7 @@ export const ipcRenderer = {
   invoke(channel: string, ...args: unknown[]): Promise<unknown> {
     if (channel === "codex_desktop:message-from-view" && args.length === 1) {
       if (isOpenInBrowserMessage(args[0])) {
-        window.open(args[0].url, "_blank", "noopener,noreferrer");
+        openExternalUrl(args[0].url);
       }
 
       if (isLocalFilePickerMessage(args[0])) {

--- a/src/server/electron/index.ts
+++ b/src/server/electron/index.ts
@@ -32,11 +32,18 @@ type IpcMainEvent = {
 };
 
 type IpcMainBridgeState = {
-  broadcastToRenderer?: (message: {
-    type: "ipc-main-event";
-    channel: string;
-    args: unknown[];
-  }) => void;
+  broadcastToRenderer?: (
+    message:
+      | {
+          type: "ipc-main-event";
+          channel: string;
+          args: unknown[];
+        }
+      | {
+          type: "open-external";
+          url: string;
+        },
+  ) => void;
   handleRendererInvoke?: (
     channel: string,
     args: unknown[],
@@ -440,8 +447,8 @@ class BrowserWindow {
         getURL: (): string => {
           log(`BrowserWindow#${this.id}.webContents.getURL`, []);
           return String(
-            (this.webContents.mainFrame as { url?: string } | undefined)
-              ?.url ?? "",
+            (this.webContents.mainFrame as { url?: string } | undefined)?.url ??
+              "",
           );
         },
         isDestroyed: (): boolean => this.destroyed,
@@ -502,10 +509,7 @@ class BrowserWindow {
 
   static getFocusedWindow(): BrowserWindow | null {
     log("BrowserWindow.getFocusedWindow", []);
-    if (
-      BrowserWindow.focusedWindow &&
-      !BrowserWindow.focusedWindow.destroyed
-    ) {
+    if (BrowserWindow.focusedWindow && !BrowserWindow.focusedWindow.destroyed) {
       return BrowserWindow.focusedWindow;
     }
     return BrowserWindow.getAllWindows()[0] ?? null;
@@ -755,6 +759,31 @@ const dialog = {
   },
 };
 
+const shell = {
+  async openExternal(value: string): Promise<void> {
+    let externalUrl: URL;
+    try {
+      externalUrl = new URL(value);
+    } catch {
+      throw new Error("Invalid external URL");
+    }
+    if (!new Set(["http:", "https:"]).has(externalUrl.protocol)) {
+      throw new Error(
+        `Unsupported external URL protocol: ${externalUrl.protocol}`,
+      );
+    }
+
+    const broadcastToRenderer = getIpcMainBridgeState().broadcastToRenderer;
+    if (!broadcastToRenderer) {
+      throw new Error("No browser renderer is connected");
+    }
+    broadcastToRenderer({
+      type: "open-external",
+      url: externalUrl.toString(),
+    });
+  },
+};
+
 const crashReporter = {
   start(...args: unknown[]): void {
     log("crashReporter.start", args);
@@ -933,14 +962,19 @@ function createSessionStub(label: string): {
     },
   };
 }
-const partitionSessions = new Map<string, ReturnType<typeof createSessionStub>>();
+const partitionSessions = new Map<
+  string,
+  ReturnType<typeof createSessionStub>
+>();
 const session = {
   defaultSession: createSessionStub("session.defaultSession"),
   fromPartition(partition: string): ReturnType<typeof createSessionStub> {
     log("session.fromPartition", [partition]);
     let partitionSession = partitionSessions.get(partition);
     if (!partitionSession) {
-      partitionSession = createSessionStub(`session.fromPartition(${partition})`);
+      partitionSession = createSessionStub(
+        `session.fromPartition(${partition})`,
+      );
       partitionSessions.set(partition, partitionSession);
     }
     return partitionSession;
@@ -988,6 +1022,7 @@ const electronModule = new Proxy(
     protocol,
     screen,
     session,
+    shell,
     Tray,
     utilityProcess,
     WebContentsView,
@@ -1021,6 +1056,7 @@ export {
   protocol,
   screen,
   session,
+  shell,
   Tray,
   utilityProcess,
   WebContentsView,

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -17,6 +17,10 @@ import fastifyMultipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import { installModuleAliasHook } from "./module";
 import { glob } from "glob";
+import {
+  forwardRemoteControlOAuthCallback,
+  parseRemoteControlOAuthCallbackUrl,
+} from "./oauth-callback";
 
 type ServerOptions = {
   host: string;
@@ -58,6 +62,11 @@ type RendererToMainMessage =
       requestId: string;
       directoryPath: string | null;
       directoriesOnly: boolean;
+    }
+  | {
+      type: "oauth-callback-forward";
+      requestId: string;
+      callbackUrl: string;
     };
 
 type MainToRendererMessage =
@@ -98,6 +107,21 @@ type MainToRendererMessage =
   | {
       type: "message-port-close";
       portId: string;
+    }
+  | {
+      type: "oauth-callback-forward-result";
+      requestId: string;
+      ok: true;
+    }
+  | {
+      type: "oauth-callback-forward-result";
+      requestId: string;
+      ok: false;
+      errorMessage: string;
+    }
+  | {
+      type: "open-external";
+      url: string;
     };
 
 type WorkspaceDirectoryEntry = {
@@ -550,6 +574,35 @@ async function startIpcBridgeServer(options: ServerOptions): Promise<void> {
 
       if (message.type === "message-port-close") {
         messagePorts.get(message.portId)?.disconnect();
+        return;
+      }
+
+      if (message.type === "oauth-callback-forward") {
+        const { requestId } = message;
+        Promise.resolve()
+          .then(() => parseRemoteControlOAuthCallbackUrl(message.callbackUrl))
+          .then((callback) => forwardRemoteControlOAuthCallback(callback))
+          .then(() => {
+            const payload: MainToRendererMessage = {
+              type: "oauth-callback-forward-result",
+              requestId,
+              ok: true,
+            };
+            if (socket.readyState === WebSocket.OPEN) {
+              socket.send(JSON.stringify(payload));
+            }
+          })
+          .catch((error) => {
+            const payload: MainToRendererMessage = {
+              type: "oauth-callback-forward-result",
+              requestId,
+              ok: false,
+              errorMessage: errorMessage(error),
+            };
+            if (socket.readyState === WebSocket.OPEN) {
+              socket.send(JSON.stringify(payload));
+            }
+          });
         return;
       }
 

--- a/src/server/oauth-callback.ts
+++ b/src/server/oauth-callback.ts
@@ -1,0 +1,124 @@
+import http from "node:http";
+
+const CALLBACK_PATH = "/auth/callback";
+const CALLBACK_PORTS = new Set([1455, 1457]);
+const LOOPBACK_HOSTS = ["::1", "127.0.0.1"] as const;
+const MAX_CALLBACK_LENGTH = 16_384;
+
+export type RemoteControlOAuthCallback = {
+  path: typeof CALLBACK_PATH;
+  port: number;
+  search: string;
+};
+
+export function parseRemoteControlOAuthCallbackUrl(
+  value: unknown,
+): RemoteControlOAuthCallback {
+  if (typeof value !== "string" || value.length > MAX_CALLBACK_LENGTH) {
+    throw new Error("Invalid remote-control OAuth callback URL");
+  }
+
+  let callbackUrl: URL;
+  try {
+    callbackUrl = new URL(value.trim());
+  } catch {
+    throw new Error("Invalid remote-control OAuth callback URL");
+  }
+
+  if (
+    callbackUrl.protocol !== "http:" ||
+    callbackUrl.hostname !== "localhost" ||
+    !CALLBACK_PORTS.has(Number(callbackUrl.port)) ||
+    callbackUrl.pathname !== CALLBACK_PATH ||
+    callbackUrl.username !== "" ||
+    callbackUrl.password !== "" ||
+    callbackUrl.hash !== ""
+  ) {
+    throw new Error("Unsupported remote-control OAuth callback URL");
+  }
+
+  const state = callbackUrl.searchParams.get("state");
+  const code = callbackUrl.searchParams.get("code");
+  const error = callbackUrl.searchParams.get("error");
+  if (!state) {
+    throw new Error("Remote-control OAuth callback is missing state");
+  }
+  if (!code && !error) {
+    throw new Error("Remote-control OAuth callback is missing a result");
+  }
+
+  return {
+    path: CALLBACK_PATH,
+    port: Number(callbackUrl.port),
+    search: callbackUrl.search,
+  };
+}
+
+export async function forwardRemoteControlOAuthCallback(
+  callback: RemoteControlOAuthCallback,
+  options: {
+    hosts?: readonly string[];
+    timeoutMs?: number;
+  } = {},
+): Promise<void> {
+  const hosts = options.hosts ?? LOOPBACK_HOSTS;
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  let lastError: unknown;
+
+  for (const host of hosts) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const request = http.request(
+          {
+            headers: {
+              Connection: "close",
+              Host: `localhost:${callback.port}`,
+            },
+            host,
+            method: "GET",
+            path: `${callback.path}${callback.search}`,
+            port: callback.port,
+          },
+          (response) => {
+            response.resume();
+            response.once("end", () => {
+              const statusCode = response.statusCode ?? 500;
+              if (statusCode >= 200 && statusCode < 300) {
+                resolve();
+                return;
+              }
+              reject(
+                new Error(
+                  `Remote-control OAuth callback was rejected (${statusCode})`,
+                ),
+              );
+            });
+          },
+        );
+
+        request.setTimeout(timeoutMs, () => {
+          request.destroy(new Error("Remote-control OAuth callback timed out"));
+        });
+        request.once("error", reject);
+        request.end();
+      });
+      return;
+    } catch (error) {
+      lastError = error;
+      const code =
+        typeof error === "object" && error !== null && "code" in error
+          ? String(error.code)
+          : null;
+      if (!new Set(["EADDRNOTAVAIL", "ECONNREFUSED"]).has(code ?? "")) {
+        throw error;
+      }
+    }
+  }
+
+  throw (
+    lastError ??
+    new Error(
+      `No loopback OAuth listener is available on port ${callback.port}`,
+    )
+  );
+}

--- a/test/electron-shell.test.mjs
+++ b/test/electron-shell.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import electron from "../src/server/electron/index.js";
+
+test("forwards safe external URLs to the browser renderer", async () => {
+  let received;
+  globalThis.__codexElectronIpcBridge = {
+    broadcastToRenderer(message) {
+      received = message;
+    },
+  };
+
+  await electron.shell.openExternal(
+    "https://auth.openai.com/oauth/authorize?client_id=test-client",
+  );
+
+  assert.deepEqual(received, {
+    type: "open-external",
+    url: "https://auth.openai.com/oauth/authorize?client_id=test-client",
+  });
+});
+
+test("rejects unsafe external URL protocols", async () => {
+  await assert.rejects(
+    electron.shell.openExternal("javascript:alert(1)"),
+    /Unsupported external URL protocol/u,
+  );
+});

--- a/test/oauth-callback.test.mjs
+++ b/test/oauth-callback.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import {
+  forwardRemoteControlOAuthCallback,
+  parseRemoteControlOAuthCallbackUrl,
+} from "../src/server/oauth-callback.js";
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test("accepts only expected localhost callback URLs", () => {
+  assert.deepEqual(
+    parseRemoteControlOAuthCallbackUrl(
+      "http://localhost:1455/auth/callback?code=test-code&state=test-state",
+    ),
+    {
+      path: "/auth/callback",
+      port: 1455,
+      search: "?code=test-code&state=test-state",
+    },
+  );
+  assert.deepEqual(
+    parseRemoteControlOAuthCallbackUrl(
+      "http://localhost:1457/auth/callback?error=access_denied&state=test-state",
+    ),
+    {
+      path: "/auth/callback",
+      port: 1457,
+      search: "?error=access_denied&state=test-state",
+    },
+  );
+
+  for (const value of [
+    "https://localhost:1455/auth/callback?code=test&state=test",
+    "http://127.0.0.1:1455/auth/callback?code=test&state=test",
+    "http://example.test:1455/auth/callback?code=test&state=test",
+    "http://user@localhost:1455/auth/callback?code=test&state=test",
+    "http://localhost:1455/not-the-callback?code=test&state=test",
+    "http://localhost:8080/auth/callback?code=test&state=test",
+    "http://localhost:1455/auth/callback?code=test&state=test#fragment",
+    "http://localhost:1455/auth/callback?code=test",
+    "http://localhost:1455/auth/callback?state=test",
+    null,
+  ]) {
+    assert.throws(
+      () => parseRemoteControlOAuthCallbackUrl(value),
+      /remote-control OAuth callback/iu,
+    );
+  }
+});
+
+test("forwards a validated callback only to a loopback listener", async () => {
+  let receivedUrl = null;
+  let receivedHost = null;
+  const callbackServer = http.createServer((request, response) => {
+    receivedUrl = request.url;
+    receivedHost = request.headers.host;
+    response.writeHead(200, { "Content-Type": "text/plain" });
+    response.end("ok");
+  });
+  await listen(callbackServer);
+
+  try {
+    const address = callbackServer.address();
+    assert(address && typeof address === "object");
+    await forwardRemoteControlOAuthCallback(
+      {
+        path: "/auth/callback",
+        port: address.port,
+        search: "?code=test-code&state=test-state",
+      },
+      { hosts: ["127.0.0.1"] },
+    );
+    assert.equal(receivedHost, `localhost:${address.port}`);
+    assert.equal(receivedUrl, "/auth/callback?code=test-code&state=test-state");
+  } finally {
+    await close(callbackServer);
+  }
+});
+
+test("does not include callback parameters in forwarding errors", async () => {
+  const callbackServer = http.createServer((_request, response) => {
+    response.writeHead(400);
+    response.end("rejected");
+  });
+  await listen(callbackServer);
+
+  try {
+    const address = callbackServer.address();
+    assert(address && typeof address === "object");
+    await assert.rejects(
+      forwardRemoteControlOAuthCallback(
+        {
+          path: "/auth/callback",
+          port: address.port,
+          search: "?code=must-not-appear&state=test-state",
+        },
+        { hosts: ["127.0.0.1"] },
+      ),
+      (error) => {
+        assert(error instanceof Error);
+        assert.match(error.message, /rejected \(400\)/u);
+        assert.doesNotMatch(error.message, /must-not-appear/u);
+        return true;
+      },
+    );
+  } finally {
+    await close(callbackServer);
+  }
+});


### PR DESCRIPTION
## Summary

- add a browser completion dialog for remote-control OAuth flows that redirect to localhost
- validate pasted callbacks and forward them only to loopback listeners on ports 1455 or 1457
- implement safe `shell.openExternal` forwarding for authorization links
- document the hosted-browser flow and add focused security and forwarding tests

## Why

Remote-control authorization uses a registered callback such as
`http://localhost:1455/auth/callback`. When codex-web runs on another machine,
the user's browser is redirected to its own localhost rather than the machine
running the Codex listener, so authorization cannot complete.

For recognized remote-control authorization URLs, this change presents a
user-clicked authorization link and asks the user to paste the complete
localhost callback URL after OpenAI redirects. The callback then travels over
the existing browser IPC WebSocket and is forwarded internally to the
server-side loopback listener.

## Security

- no public callback endpoint is added
- only HTTP localhost callbacks using `/auth/callback` on ports 1455 and 1457 are accepted
- callbacks must contain `state` and either `code` or `error`
- callback URLs with credentials, fragments, other hosts, paths, protocols, or ports are rejected
- the callback is not logged, persisted, or included in forwarding errors
- external URL forwarding permits only HTTP and HTTPS

## Validation

- `npm ci`
- `npm test`
- `npm run build:browser`
- `git diff --check`
- five passing tests covering safe external links, invalid callback variants, loopback forwarding, and callback-value redaction from errors
