### PR TITLE
Fix browser tab isolation and app-host reconnects

### DIFF
--- a/patches/app-host-browser-windows.patch
+++ b/patches/app-host-browser-windows.patch
@@ -1,0 +1,48 @@
+--- a/.vite/build/main-C5K7o1Hr.js
++++ b/.vite/build/main-C5K7o1Hr.js
+@@ -130136,28 +130136,22 @@
+         }));
+     }
+     async whenReady() {
++      // Browser tabs are independent renderers. Opening another tab must not
++      // cancel startup for an existing tab when the primary window changes.
+       if (this.startupReady != null) {
+         let e = Promise.withResolvers(),
+           t = () => {
+-            e.reject(
+-              new DOMException(`Primary renderer was replaced`, `AbortError`),
+-            );
+-          },
+-          n = this.windowManager.subscribePrimaryWindowChanges((e) => {
+-            e?.webContents.id !== this.origin.id && t();
+-          });
++            e.reject(new DOMException(`Renderer was destroyed`, `AbortError`));
++          };
+         this.origin.once(`destroyed`, t);
+         try {
+           await Promise.race([this.startupReady, e.promise]);
+         } finally {
+-          (n(), this.origin.off(`destroyed`, t));
++          this.origin.off(`destroyed`, t);
+         }
+       }
+-      if (
+-        this.isDisposed ||
+-        this.windowManager.getPrimaryWindow()?.webContents.id !== this.origin.id
+-      )
+-        throw new DOMException(`Primary renderer was replaced`, `AbortError`);
++      if (this.origin.isDestroyed())
++        throw new DOMException(`Renderer was destroyed`, `AbortError`);
+     }
+     reach(e) {
+       if (
+@@ -151649,6 +151643,9 @@
+     updateDockIcon: ee,
+     setWindowContext: (e) => {
+       L = e;
++      globalThis.__codexElectronIpcBridge?.setRendererWindowFactory(() =>
++        R.createPrimaryWindow({ show: !1 }),
++      );
+       for (let t of l.BrowserWindow.getAllWindows())
+         t.isDestroyed() || !R.isAppServiceWindow(t) || e.registerWindow(t);
+     },

--- a/scripts/prepare_asar
+++ b/scripts/prepare_asar
@@ -41,4 +41,5 @@ patch --batch --forward --strip 1 --directory scratch/asar < patches/sentry-disa
 patch --batch --forward --strip 1 --directory scratch/asar < patches/preload-disable-device-check.patch
 patch --batch --forward --strip 1 --directory scratch/asar < patches/webview-safe-header-left.patch
 patch --batch --forward --strip 1 --directory scratch/asar < patches/app-host-json-rpc.patch
+patch --batch --forward --strip 1 --directory scratch/asar < patches/app-host-browser-windows.patch
 rm -rf scratch/asar/node_modules/better-sqlite3

--- a/src/browser/shim.ts
+++ b/src/browser/shim.ts
@@ -130,7 +130,7 @@ declare const __CODEX_APP_VERSION__: string;
 
 let requestCounter = 0;
 let socket: WebSocket | null = null;
-let hasConnected = false;
+let needsReload = false;
 let reconnectTimeoutId: number | null = null;
 const outboundQueue: RendererToMainMessage[] = [];
 const pendingInvokes = new Map<
@@ -246,11 +246,10 @@ function ensureSocket(): void {
   socket.addEventListener("open", () => {
     // App-host RPC transfers MessagePorts once at startup. A new connection needs
     // a fresh app view; replaying requests against the closed ports cannot recover it.
-    if (hasConnected) {
+    if (needsReload) {
       window.location.reload();
       return;
     }
-    hasConnected = true;
     flushOutboundQueue();
   });
   socket.addEventListener("message", (event) => {
@@ -265,6 +264,7 @@ function ensureSocket(): void {
     }
   });
   socket.addEventListener("close", () => {
+    needsReload = true;
     const error = new Error("Connection to Codex was lost");
     for (const pending of pendingInvokes.values()) pending.reject(error);
     pendingInvokes.clear();

--- a/src/browser/shim.ts
+++ b/src/browser/shim.ts
@@ -130,6 +130,7 @@ declare const __CODEX_APP_VERSION__: string;
 
 let requestCounter = 0;
 let socket: WebSocket | null = null;
+let hasConnected = false;
 let reconnectTimeoutId: number | null = null;
 const outboundQueue: RendererToMainMessage[] = [];
 const pendingInvokes = new Map<
@@ -243,6 +244,13 @@ function ensureSocket(): void {
     `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}/__backend/ipc`,
   );
   socket.addEventListener("open", () => {
+    // App-host RPC transfers MessagePorts once at startup. A new connection needs
+    // a fresh app view; replaying requests against the closed ports cannot recover it.
+    if (hasConnected) {
+      window.location.reload();
+      return;
+    }
+    hasConnected = true;
     flushOutboundQueue();
   });
   socket.addEventListener("message", (event) => {
@@ -257,6 +265,13 @@ function ensureSocket(): void {
     }
   });
   socket.addEventListener("close", () => {
+    const error = new Error("Connection to Codex was lost");
+    for (const pending of pendingInvokes.values()) pending.reject(error);
+    pendingInvokes.clear();
+    for (const pending of pendingDirectoryEntries.values())
+      pending.reject(error);
+    pendingDirectoryEntries.clear();
+    outboundQueue.length = 0;
     for (const port of messagePorts.values()) {
       port.close();
     }

--- a/src/server/electron/index.ts
+++ b/src/server/electron/index.ts
@@ -32,26 +32,29 @@ type IpcMainEvent = {
 };
 
 type IpcMainBridgeState = {
-  broadcastToRenderer?: (message: {
-    type: "ipc-main-event";
-    channel: string;
-    args: unknown[];
-  }) => void;
+  sendToRenderer?: (
+    webContentsId: number,
+    message: {
+      type: "ipc-main-event";
+      channel: string;
+      args: unknown[];
+    },
+  ) => void;
   handleRendererInvoke?: (
     channel: string,
     args: unknown[],
-    sourceUrl?: string,
+    windowId: number,
   ) => Promise<unknown>;
   handleRendererPostMessage?: (
     channel: string,
     message: unknown,
     ports: StubMessagePort[],
-    sourceUrl?: string,
+    windowId: number,
   ) => void;
   handleRendererSend?: (
     channel: string,
     args: unknown[],
-    sourceUrl?: string,
+    windowId: number,
   ) => void;
 };
 
@@ -166,51 +169,28 @@ function createMessagePortStub(label: string): {
   };
 }
 
-const rendererUrl = "http://localhost:5175/";
-const rendererMainFrame = {
-  url: rendererUrl,
-};
-const rendererWebContentsEmitter = createEmitterStub("ipcMainEvent.sender");
-const rendererWebContents: StubWebContents = {
-  id: 1001,
-  mainFrame: rendererMainFrame,
-  getURL: () => rendererMainFrame.url,
-  isDestroyed: () => false,
-  off: rendererWebContentsEmitter.off,
-  on: rendererWebContentsEmitter.on,
-  once: rendererWebContentsEmitter.once,
-  removeListener: rendererWebContentsEmitter.removeListener,
-  send: (channel: string, ...args: unknown[]): void => {
-    getIpcMainBridgeState().broadcastToRenderer?.({
-      type: "ipc-main-event",
-      channel,
-      args,
-    });
-  },
-};
-
-function createIpcMainEvent(ports: StubMessagePort[] = []): IpcMainEvent {
-  const sender =
-    (BrowserWindow.fromWebContents(rendererWebContents)
-      ?.webContents as unknown as StubWebContents | undefined) ??
-    rendererWebContents;
-  const event: IpcMainEvent = {
+function createIpcMainEvent(
+  windowId: number,
+  ports: StubMessagePort[] = [],
+): IpcMainEvent {
+  const window = BrowserWindow.fromId(windowId);
+  if (!window || window.isDestroyed()) {
+    throw new Error(
+      `[electron-main-stub] Renderer window ${windowId} is closed`,
+    );
+  }
+  const sender = window.webContents as unknown as StubWebContents;
+  return {
     returnValue: undefined,
-    processId: 1,
+    processId: windowId,
     frameId: 1,
     sender,
     senderFrame: sender.mainFrame,
     ports,
     reply: (channel: string, ...args: unknown[]): void => {
-      getIpcMainBridgeState().broadcastToRenderer?.({
-        type: "ipc-main-event",
-        channel,
-        args,
-      });
+      sender.send(channel, ...args);
     },
   };
-
-  return event;
 }
 
 function createIpcMainStub(): {
@@ -231,7 +211,7 @@ function createIpcMainStub(): {
 
   const pendingPostMessages = new Map<
     string,
-    Array<{ message: unknown; ports: StubMessagePort[] }>
+    Array<{ message: unknown; ports: StubMessagePort[]; windowId: number }>
   >();
   const registeredPostMessageChannels = new Set<string>();
 
@@ -239,34 +219,36 @@ function createIpcMainStub(): {
     channel: string,
     message: unknown,
     ports: StubMessagePort[],
+    windowId: number,
   ): void => {
     if (registeredPostMessageChannels.has(channel)) {
-      emitter.emit(channel, createIpcMainEvent(ports), message);
+      emitter.emit(channel, createIpcMainEvent(windowId, ports), message);
       return;
     }
     const pending = pendingPostMessages.get(channel) ?? [];
-    pending.push({ message, ports });
+    pending.push({ message, ports, windowId });
     pendingPostMessages.set(channel, pending);
   };
 
   bridgeState.handleRendererInvoke = async (
     channel: string,
     args: unknown[],
+    windowId: number,
   ): Promise<unknown> => {
     const handler = handlers.get(channel);
     if (!handler) {
       throw new Error(`[electron-main-stub] No ipcMain.handle for ${channel}`);
     }
-    const event = createIpcMainEvent();
+    const event = createIpcMainEvent(windowId);
     return await Promise.resolve(handler(event, ...args));
   };
 
   bridgeState.handleRendererSend = (
     channel: string,
     args: unknown[],
-    sourceUrl?: string,
+    windowId: number,
   ): void => {
-    const event = createIpcMainEvent();
+    const event = createIpcMainEvent(windowId);
     emitter.emit(channel, event, ...args);
   };
 
@@ -277,8 +259,9 @@ function createIpcMainStub(): {
       const pending = pendingPostMessages.get(channel);
       if (pending) {
         pendingPostMessages.delete(channel);
-        for (const { message, ports } of pending) {
-          emitter.emit(channel, createIpcMainEvent(ports), message);
+        for (const { message, ports, windowId } of pending) {
+          if (!BrowserWindow.fromId(windowId)) continue;
+          emitter.emit(channel, createIpcMainEvent(windowId, ports), message);
         }
       }
       return result;
@@ -480,11 +463,14 @@ class BrowserWindow {
             return;
           }
           const [channel, ...args] = sendArgs as [string, ...unknown[]];
-          getIpcMainBridgeState().broadcastToRenderer?.({
-            type: "ipc-main-event",
-            channel,
-            args,
-          });
+          getIpcMainBridgeState().sendToRenderer?.(
+            this.webContents.id as number,
+            {
+              type: "ipc-main-event",
+              channel,
+              args,
+            },
+          );
         },
       } as Record<string, unknown>,
       {
@@ -580,7 +566,12 @@ class BrowserWindow {
 
   destroy(): void {
     log(`BrowserWindow#${this.id}.destroy`, []);
+    if (this.destroyed) return;
     this.destroyed = true;
+    (this.webContents.emit as StubFunction)("destroyed");
+    BrowserWindow.allWindows = BrowserWindow.allWindows.filter(
+      (window) => window !== this,
+    );
     if (BrowserWindow.focusedWindow === this) {
       BrowserWindow.focusedWindow = null;
     }

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -124,6 +124,7 @@ type BridgedMessagePort = {
 
 class WebSocketMessagePort implements BridgedMessagePort {
   private closed = false;
+  private readonly pendingMessages: unknown[] = [];
   private readonly listeners = new Map<string, Set<MessagePortListener>>();
 
   constructor(
@@ -136,6 +137,11 @@ class WebSocketMessagePort implements BridgedMessagePort {
     const listeners = this.listeners.get(event) ?? new Set();
     listeners.add(listener);
     this.listeners.set(event, listeners);
+    if (event === "message") {
+      for (const data of this.pendingMessages.splice(0)) {
+        this.receiveMessage(data);
+      }
+    }
 
     return this;
   }
@@ -169,6 +175,7 @@ class WebSocketMessagePort implements BridgedMessagePort {
     }
     const listeners = this.listeners.get("message");
     if (!listeners || listeners.size === 0) {
+      this.pendingMessages.push(data);
       return;
     }
     for (const listener of listeners) {
@@ -194,6 +201,7 @@ class WebSocketMessagePort implements BridgedMessagePort {
       return false;
     }
     this.closed = true;
+    this.pendingMessages.length = 0;
     this.onClosed();
     return true;
   }
@@ -224,16 +232,34 @@ function compareWorkspaceDirectoryEntries(
   );
 }
 
+type RendererWindow = {
+  id: number;
+  webContents: { id: number };
+  destroy: () => void;
+};
+
 type IpcMainBridgeState = {
-  broadcastToRenderer?: (message: MainToRendererMessage) => void;
-  handleRendererInvoke?: (channel: string, args: unknown[]) => Promise<unknown>;
+  setRendererWindowFactory?: (factory: () => Promise<RendererWindow>) => void;
+  sendToRenderer?: (
+    webContentsId: number,
+    message: MainToRendererMessage,
+  ) => void;
+  handleRendererInvoke?: (
+    channel: string,
+    args: unknown[],
+    windowId: number,
+  ) => Promise<unknown>;
   handleRendererPostMessage?: (
     channel: string,
     message: unknown,
     ports: BridgedMessagePort[],
-    sourceUrl?: string,
+    windowId: number,
   ) => void;
-  handleRendererSend?: (channel: string, args: unknown[]) => void;
+  handleRendererSend?: (
+    channel: string,
+    args: unknown[],
+    windowId: number,
+  ) => void;
 };
 
 function printUsage(): void {
@@ -388,7 +414,6 @@ async function startIpcBridgeServer(options: ServerOptions): Promise<void> {
   const bridgeState = getIpcMainBridgeState();
   const app = Fastify({ logger: false });
   const websocketServer = new WebSocketServer({ noServer: true });
-  const sockets = new Set<WebSocket>();
 
   await app.register(fastifyMultipart, {
     limits: {
@@ -466,28 +491,50 @@ async function startIpcBridgeServer(options: ServerOptions): Promise<void> {
     });
   });
 
-  bridgeState.broadcastToRenderer = (message: MainToRendererMessage): void => {
-    const payload = JSON.stringify(message);
-    for (const socket of sockets) {
-      if (socket.readyState === WebSocket.OPEN) {
-        socket.send(payload);
-      }
+  const rendererSockets = new Map<number, WebSocket>();
+  const rendererWindowFactory = new Promise<() => Promise<RendererWindow>>(
+    (resolve) => {
+      bridgeState.setRendererWindowFactory = resolve;
+    },
+  );
+  bridgeState.sendToRenderer = (webContentsId, message): void => {
+    const socket = rendererSockets.get(webContentsId);
+    if (socket?.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify(message));
     }
   };
 
   websocketServer.on("connection", (socket) => {
-    sockets.add(socket);
+    let rendererWindow: RendererWindow | undefined;
+    // Each tab is a real registered app view, with its own IPC client and ownership.
+    const rendererReady = rendererWindowFactory
+      .then(async (createWindow) => {
+        if (socket.readyState !== WebSocket.OPEN) return undefined;
+        const window = await createWindow();
+        if (socket.readyState !== WebSocket.OPEN) {
+          window.destroy();
+          return undefined;
+        }
+        rendererWindow = window;
+        rendererSockets.set(window.webContents.id, socket);
+        return window;
+      })
+      .catch((error) => {
+        console.error("[ipc-bridge] failed to create renderer window", error);
+        socket.close(1011, "Renderer initialization failed");
+        return undefined;
+      });
 
     const messagePorts = new Map<string, WebSocketMessagePort>();
     const dispatchPostMessage = (
       channel: string,
       message: unknown,
       ports: WebSocketMessagePort[],
-      sourceUrl?: string,
+      windowId: number,
     ): void => {
       const handler = bridgeState.handleRendererPostMessage;
       if (handler) {
-        handler(channel, message, ports, sourceUrl);
+        handler(channel, message, ports, windowId);
         return;
       }
 
@@ -500,14 +547,19 @@ async function startIpcBridgeServer(options: ServerOptions): Promise<void> {
     };
 
     socket.on("close", () => {
-      sockets.delete(socket);
       for (const port of messagePorts.values()) {
         port.disconnect();
       }
       messagePorts.clear();
+      if (rendererWindow) {
+        rendererSockets.delete(rendererWindow.webContents.id);
+        rendererWindow.destroy();
+      }
     });
 
-    socket.on("message", (rawData) => {
+    socket.on("message", async (rawData) => {
+      const window = await rendererReady;
+      if (!window || socket.readyState !== WebSocket.OPEN) return;
       let message: RendererToMainMessage;
       try {
         message = JSON.parse(String(rawData)) as RendererToMainMessage;
@@ -517,7 +569,11 @@ async function startIpcBridgeServer(options: ServerOptions): Promise<void> {
       }
 
       if (message.type === "ipc-renderer-send") {
-        bridgeState.handleRendererSend?.(message.channel, message.args);
+        bridgeState.handleRendererSend?.(
+          message.channel,
+          message.args,
+          window.id,
+        );
         return;
       }
 
@@ -545,12 +601,7 @@ async function startIpcBridgeServer(options: ServerOptions): Promise<void> {
           return port;
         });
 
-        dispatchPostMessage(
-          message.channel,
-          message.message,
-          ports,
-          message.sourceUrl,
-        );
+        dispatchPostMessage(message.channel, message.message, ports, window.id);
         return;
       }
 
@@ -595,7 +646,7 @@ async function startIpcBridgeServer(options: ServerOptions): Promise<void> {
       if (message.type === "ipc-renderer-invoke") {
         const { channel, requestId, args } = message;
         Promise.resolve(
-          bridgeState.handleRendererInvoke?.(channel, args) ??
+          bridgeState.handleRendererInvoke?.(channel, args, window.id) ??
             Promise.reject(
               new Error(
                 `[ipc-bridge] no ipcMain.handle for channel ${channel}`,


### PR DESCRIPTION
Opening or reconnecting browser tabs could leave the app loading indefinitely because all tabs shared webContents 1001 and replaced each other's app-host reply handlers. Each WebSocket now gets its own registered renderer window, targeted replies, and cleanup when it disconnects. Startup remains valid when another tab becomes primary, and reconnecting reloads the view to recreate its MessagePorts, including after a failed first connection attempt.

Validated local TypeScript and browser builds, formatting, flake checks, exact patch replay, and the final Linux NixOS build. Remote browser checks covered the reported task, new replies, two tabs of one task receiving a follow-up sent from the second tab, closing a tab, saved-history reloads, and automatic recovery after a bridge restart. After activation, both tasks resumed on distinct renderer IDs with no app-host errors.

Deployed through compute main commit 9f3327d84846d5d8b1b97e80387660c21691f646, which pins this branch at d269fa9b22775992bb9f7333ab11bd29b9890d61.
